### PR TITLE
Make compatible with API level 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,16 +17,14 @@
     <dependency>
       <groupId>android</groupId>
       <artifactId>android</artifactId>
-      <version>4.0.3_r3</version>
+      <version>2.1_r3</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>android</groupId>
-      <artifactId>annotations</artifactId>
-      <version>4.0.3_r3</version>
-      <scope>system</scope>
-      <systemPath>${ANDROID_HOME}/tools/support/annotations.jar</systemPath>
+      <groupId>com.google.android</groupId>
+      <artifactId>support-v4</artifactId>
+      <version>r7</version>
     </dependency>
   </dependencies>
   
@@ -64,7 +62,7 @@
           <assetsDirectory>${project.basedir}/assets</assetsDirectory>
           <resourceDirectory>${project.basedir}/res</resourceDirectory>
           <sdk>
-            <platform>11</platform>
+            <platform>7</platform>
           </sdk>
           <deleteConflictingFiles>true</deleteConflictingFiles>
           <undeployBeforeDeploy>true</undeployBeforeDeploy>

--- a/src/main/java/net/hockeyapp/android/UpdateFragment.java
+++ b/src/main/java/net/hockeyapp/android/UpdateFragment.java
@@ -9,7 +9,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 import android.app.Activity;
-import android.app.DialogFragment;
+import android.support.v4.app.DialogFragment;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
@@ -114,8 +114,9 @@ public class UpdateFragment extends DialogFragment implements OnClickListener, U
       dismiss();
       return;
     }
-    
-    setStyle(DialogFragment.STYLE_NO_TITLE, android.R.style.Theme_Holo_Light_Dialog);
+
+    // theme 0 chooses "an appropriate theme (based on the style)"
+    setStyle(DialogFragment.STYLE_NO_TITLE, 0);
   }
   
   /**

--- a/src/main/java/net/hockeyapp/android/UpdateManager.java
+++ b/src/main/java/net/hockeyapp/android/UpdateManager.java
@@ -3,10 +3,9 @@ package net.hockeyapp.android;
 import java.util.Date;
 
 import net.hockeyapp.android.internal.CheckUpdateTask;
-import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.app.Activity;
-import android.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.Fragment;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.AsyncTask.Status;
@@ -58,12 +57,17 @@ public class UpdateManager {
   private static UpdateManagerListener lastListener = null;
 
   /**
+   * The value of Configuration.SCREENLAYOUT_SIZE_XLARGE. Not added till API 9, so we recreate it here.
+   */
+  private static final int SCREENLAYOUT_SIZE_XLARGE = 4;
+
+  /**
    * Registers new update manager.
    * 
    * @param activity Parent activity.
    * @param appIdentifier App ID of your app on HockeyApp.
    */
-  public static void register(Activity activity, String appIdentifier) {
+  public static void register(FragmentActivity activity, String appIdentifier) {
     register(activity, appIdentifier, null);
   }
   
@@ -74,7 +78,7 @@ public class UpdateManager {
    * @param appIdentifier App ID of your app on HockeyApp.
    * @param listener Implement for callback functions.
    */
-  public static void register(Activity activity, String appIdentifier, UpdateManagerListener listener) {
+  public static void register(FragmentActivity activity, String appIdentifier, UpdateManagerListener listener) {
     register(activity, Constants.BASE_URL, appIdentifier, listener);
   }
   
@@ -86,7 +90,7 @@ public class UpdateManager {
    * @param appIdentifier App ID of your app on HockeyApp.
    * @param listener Implement for callback functions.
    */
-  public static void register(Activity activity, String urlString, String appIdentifier, UpdateManagerListener listener) {
+  public static void register(FragmentActivity activity, String urlString, String appIdentifier, UpdateManagerListener listener) {
     lastListener = listener;
     
     if ((fragmentsSupported()) && (dialogShown(activity))) {
@@ -150,7 +154,7 @@ public class UpdateManager {
    * Starts the UpdateTask if not already running. Otherwise attaches the
    * activity to it. 
    */
-  private static void startUpdateTask(Activity activity, String urlString, String appIdentifier, UpdateManagerListener listener) {
+  private static void startUpdateTask(FragmentActivity activity, String urlString, String appIdentifier, UpdateManagerListener listener) {
     if ((updateTask == null) || (updateTask.getStatus() == Status.FINISHED)) {
       updateTask = new CheckUpdateTask(activity, urlString, appIdentifier, listener);
       updateTask.execute();
@@ -163,31 +167,28 @@ public class UpdateManager {
   /**
    * Returns true if the dialog is already shown (only works on Android 3.0+). 
    */
-  @TargetApi(11)
-  private static boolean dialogShown(Activity activity) {
-    Fragment existingFragment = activity.getFragmentManager().findFragmentByTag("hockey_update_dialog");
+  private static boolean dialogShown(FragmentActivity activity) {
+    Fragment existingFragment = activity.getSupportFragmentManager().findFragmentByTag("hockey_update_dialog");
     return (existingFragment != null);
   }
 
   /**
    * Returns true if the Fragment API is supported (should be on Android 3.0+).
    */
-  @SuppressLint("NewApi")
   public static Boolean fragmentsSupported() {
-    try {
-      return (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) && (android.app.Fragment.class != null);
-    }
-    catch (NoClassDefFoundError e) {
-      return false;
-    }
+    return true;
   }
+
+  // Not added till API 9, so we recreate it here
+  private static final int SCREENLAYOUT_SIZE_XLARGE = 4;
 
   /**
    * Returns true if the app runs on large or very large screens (i.e. tablets). 
    */
   public static Boolean runsOnTablet(Activity activity) {
     Configuration configuration = activity.getResources().getConfiguration();
-    return (((configuration.screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) == Configuration.SCREENLAYOUT_SIZE_LARGE) || ((configuration.screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) == Configuration.SCREENLAYOUT_SIZE_XLARGE));
+
+    return (((configuration.screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) == Configuration.SCREENLAYOUT_SIZE_LARGE) || ((configuration.screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) == SCREENLAYOUT_SIZE_XLARGE));
   }
 
   /**

--- a/src/main/java/net/hockeyapp/android/internal/CheckUpdateTask.java
+++ b/src/main/java/net/hockeyapp/android/internal/CheckUpdateTask.java
@@ -25,9 +25,10 @@ import org.json.JSONObject;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.DialogFragment;
-import android.app.Fragment;
-import android.app.FragmentTransaction;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentTransaction;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -75,13 +76,13 @@ import android.widget.Toast;
 public class CheckUpdateTask extends AsyncTask<String, String, JSONArray>{
   protected String urlString = null;
   protected String appIdentifier = null;
-  
-  private Activity activity = null;
+
+  private FragmentActivity activity = null;
   private Boolean mandatory = false;
   private UpdateManagerListener listener;
   private long usageTime = 0;
-  
-  public CheckUpdateTask(Activity activity, String urlString) {
+
+  public CheckUpdateTask(FragmentActivity activity, String urlString) {
     this.appIdentifier = null;
     this.activity = activity;
     this.urlString = urlString;
@@ -89,8 +90,8 @@ public class CheckUpdateTask extends AsyncTask<String, String, JSONArray>{
     
     Constants.loadFromContext(activity);
   }
-  
-  public CheckUpdateTask(Activity activity, String urlString, String appIdentifier) {
+
+  public CheckUpdateTask(FragmentActivity activity, String urlString, String appIdentifier) {
     this.appIdentifier = appIdentifier;
     this.activity = activity;
     this.urlString = urlString;
@@ -98,8 +99,8 @@ public class CheckUpdateTask extends AsyncTask<String, String, JSONArray>{
 
     Constants.loadFromContext(activity);
   }
-  
-  public CheckUpdateTask(Activity activity, String urlString, String appIdentifier, UpdateManagerListener listener) {
+
+  public CheckUpdateTask(FragmentActivity activity, String urlString, String appIdentifier, UpdateManagerListener listener) {
     this.appIdentifier = appIdentifier;
     this.activity = activity;
     this.urlString = urlString;
@@ -109,7 +110,7 @@ public class CheckUpdateTask extends AsyncTask<String, String, JSONArray>{
     Constants.loadFromContext(activity);
   }
 
-  public void attach(Activity activity) {
+  public void attach(FragmentActivity activity) {
     this.activity = activity;
 
     Constants.loadFromContext(activity);
@@ -304,10 +305,10 @@ public class CheckUpdateTask extends AsyncTask<String, String, JSONArray>{
   }
 
   private void showUpdateFragment(final JSONArray updateInfo) {
-    FragmentTransaction fragmentTransaction = activity.getFragmentManager().beginTransaction();
+    FragmentTransaction fragmentTransaction = activity.getSupportFragmentManager().beginTransaction();
     fragmentTransaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
-    
-    Fragment existingFragment = activity.getFragmentManager().findFragmentByTag("hockey_update_dialog");
+
+    Fragment existingFragment = activity.getSupportFragmentManager().findFragmentByTag("hockey_update_dialog");
     if (existingFragment != null) {
       fragmentTransaction.remove(existingFragment);
     }

--- a/src/main/java/net/hockeyapp/android/internal/ExpiryInfoView.java
+++ b/src/main/java/net/hockeyapp/android/internal/ExpiryInfoView.java
@@ -56,14 +56,14 @@ public class ExpiryInfoView extends RelativeLayout {
   }
 
   private void loadLayoutParams(Context context) {
-    LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
+    LayoutParams params = new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT);
     setBackgroundColor(Color.WHITE);
     setLayoutParams(params);
   }
 
   private void loadShadowView(Context context) {
     int height = (int)TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, (float)3.0, getResources().getDisplayMetrics());
-    LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT, height);
+    LayoutParams params = new LayoutParams(LayoutParams.FILL_PARENT, height);
     params.addRule(RelativeLayout.ALIGN_PARENT_TOP, TRUE);
 
     ImageView shadowView = new ImageView(context);
@@ -76,7 +76,7 @@ public class ExpiryInfoView extends RelativeLayout {
   private void loadTextView(Context context, String text) {
     int margin = (int)TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, (float)20.0, getResources().getDisplayMetrics());
 
-    LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
+    LayoutParams params = new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT);
     params.addRule(RelativeLayout.CENTER_IN_PARENT, TRUE);
     params.setMargins(margin, margin, margin, margin);
     

--- a/src/main/java/net/hockeyapp/android/internal/UpdateView.java
+++ b/src/main/java/net/hockeyapp/android/internal/UpdateView.java
@@ -102,7 +102,7 @@ public class UpdateView extends RelativeLayout {
   }
 
   private void loadLayoutParams(Context context) {
-    LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
+    LayoutParams params = new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT);
     setBackgroundColor(Color.WHITE);
     setLayoutParams(params);
   }
@@ -113,12 +113,12 @@ public class UpdateView extends RelativeLayout {
     
     LayoutParams params = null;
     if (layoutHorizontally) {
-      params = new LayoutParams((int)TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, (float)250.0, getResources().getDisplayMetrics()), LayoutParams.MATCH_PARENT);
+      params = new LayoutParams((int)TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, (float)250.0, getResources().getDisplayMetrics()), LayoutParams.FILL_PARENT);
       params.addRule(RelativeLayout.ALIGN_PARENT_LEFT, TRUE);
       headerView.setPadding(0, 0, 0, 0);
     }
     else {
-      params = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
+      params = new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT);
       headerView.setPadding(0, 0, 0, (int)TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, (float)20.0, getResources().getDisplayMetrics()));
     }
     headerView.setLayoutParams(params);
@@ -204,12 +204,12 @@ public class UpdateView extends RelativeLayout {
     
     ImageView topShadowView = new ImageView(context);
     if (layoutHorizontally) {
-      params = new LayoutParams(1, LayoutParams.MATCH_PARENT);
+      params = new LayoutParams(1, LayoutParams.FILL_PARENT);
       params.addRule(RelativeLayout.ALIGN_PARENT_RIGHT, TRUE);
       topShadowView.setBackgroundDrawable(new ColorDrawable(Color.BLACK));
     }
     else {
-      params = new LayoutParams(LayoutParams.MATCH_PARENT, height);
+      params = new LayoutParams(LayoutParams.FILL_PARENT, height);
       params.addRule(RelativeLayout.ALIGN_PARENT_TOP, TRUE);
       topShadowView.setBackgroundDrawable(ViewHelper.getGradient());
     }
@@ -218,7 +218,7 @@ public class UpdateView extends RelativeLayout {
     headerView.addView(topShadowView);
     
     ImageView bottomShadowView = new ImageView(context);
-    params = new LayoutParams(LayoutParams.MATCH_PARENT, height);
+    params = new LayoutParams(LayoutParams.FILL_PARENT, height);
     if (layoutHorizontally) {
       params.addRule(RelativeLayout.ALIGN_PARENT_TOP, TRUE);
     }
@@ -236,7 +236,7 @@ public class UpdateView extends RelativeLayout {
     webView.setId(WEB_VIEW_ID);
     
     int height = (int)TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 400, context.getResources().getDisplayMetrics());
-    LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT, (this.limitHeight ? height : LayoutParams.MATCH_PARENT));
+    LayoutParams params = new LayoutParams(LayoutParams.FILL_PARENT, (this.limitHeight ? height : LayoutParams.FILL_PARENT));
     if (layoutHorizontally) {
       params.addRule(RIGHT_OF, HEADER_VIEW_ID);
     }


### PR DESCRIPTION
This reworks the library to use the Android support jar such that it can use fragments and still compile against API level 7.

There are a couple drawbacks of the current technique for apps targeting versions of Android < 3.0:
- HockeyApp's update system isn't usable on those OSes
- The app has to change its SDK version to target 11, which makes it easy to use incompatible APIs

As far as I know, there's no way to automatically switch between using support's fragments and builtin fragments. That means this will need to be maintained as a separate branch. That said, the changes are minor, and it should be easy to pull changes over from the main branch into this one or vice versa.
