### PR TITLE
Fixed FindBugs warnings which might affect stability

### DIFF
--- a/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -476,7 +476,10 @@ public class CrashManager {
   private static String[] searchForStackTraces() {
     // Try to create the files folder if it doesn't exist
     File dir = new File(Constants.FILES_PATH + "/");
-    dir.mkdir();
+    boolean created = dir.mkdir();
+    if (!created && !dir.exists()) {
+      return new String[0];
+    }
 
     // Filter for ".stacktrace" files
     FilenameFilter filter = new FilenameFilter() { 

--- a/src/main/java/net/hockeyapp/android/internal/DownloadFileTask.java
+++ b/src/main/java/net/hockeyapp/android/internal/DownloadFileTask.java
@@ -93,7 +93,10 @@ public class DownloadFileTask extends AsyncTask<String, Integer, Boolean>{
       int lenghtOfFile = connection.getContentLength();
 
       File dir = new File(this.filePath);
-      dir.mkdirs();
+      boolean result = dir.mkdirs();
+      if (!result && !dir.exists()) {
+        throw new IOException("Could not create the dir(s):" + dir.getAbsolutePath());
+      }
       File file = new File(dir, this.filename);
 
       InputStream input = new BufferedInputStream(connection.getInputStream());


### PR DESCRIPTION
Basically, the result of mkdir(s) should be checked, as exceptional
circumstances can block dirs from being created, which could lead to
at least one NullPointerException.
