### PR TITLE
connection=close disabled for SDK>2.x

### DIFF
--- a/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTask.java
+++ b/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTask.java
@@ -192,7 +192,10 @@ public class CheckUpdateTask extends AsyncTask<String, String, JSONArray>{
   protected URLConnection createConnection(URL url) throws IOException {
     URLConnection connection = url.openConnection();
     connection.addRequestProperty("User-Agent", "Hockey/Android");
-    connection.setRequestProperty("connection", "close");
+    // connection bug workaround for SDK<=2.x
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD) {
+      connection.setRequestProperty("connection", "close");
+    }
     return connection;
   }
 


### PR DESCRIPTION
Bei SDK>2.3 führt connection=close zum Vorzeitigen schliessen der connection. Auf einem mobilen Netz führt es dazu, dass die HockeyApp-app keine Informationen über vorhandene Releases der Apps holen kann und mit 'Keine Releases vorhanden' antwortet.
