### PR TITLE
Show the feedback activity as part of a new task. Avoids issues where ca...

### DIFF
--- a/src/main/java/net/hockeyapp/android/FeedbackManager.java
+++ b/src/main/java/net/hockeyapp/android/FeedbackManager.java
@@ -114,6 +114,7 @@ public class FeedbackManager {
       }
       
       Intent intent = new Intent();
+      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       intent.setClass(context, activityClass);
       intent.putExtra("url", getURLString(context));
       context.startActivity(intent);


### PR DESCRIPTION
Show the feedback activity as part of a new task. Avoids issues where calling showFeedbackActivity crashed inside of (i.e.: PhoneGap/Cordova).

It seems reasonable to always start a new task when launching the feedback form. Can any one think of a reason for why this behavior shouldn't be in across the board?
