### PR TITLE
Use ConnectionManager singleton when posting crash stacks.

### DIFF
--- a/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 
 
+import net.hockeyapp.android.utils.ConnectionManager;
 import net.hockeyapp.android.utils.PrefsUtil;
 
 import org.apache.http.NameValuePair;
@@ -249,9 +250,8 @@ public class CrashManager {
           if (stacktrace.length() > 0) {
             // Transmit stack trace with POST request
             Log.d(Constants.TAG, "Transmitting crash data: \n" + stacktrace);
-            DefaultHttpClient httpClient = new DefaultHttpClient(); 
+            DefaultHttpClient httpClient = (DefaultHttpClient)ConnectionManager.getInstance().getHttpClient();
             HttpPost httpPost = new HttpPost(getURLString());
-            httpPost.setHeader("User-Agent", "HockeySDK/Android");
             
             List <NameValuePair> parameters = new ArrayList <NameValuePair>(); 
             parameters.add(new BasicNameValuePair("raw", stacktrace));

--- a/src/main/java/net/hockeyapp/android/utils/ConnectionManager.java
+++ b/src/main/java/net/hockeyapp/android/utils/ConnectionManager.java
@@ -9,6 +9,7 @@ import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.CoreProtocolPNames;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
 
@@ -26,7 +27,8 @@ public class ConnectionManager {
     HttpParams params = new BasicHttpParams();
     HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
     HttpProtocolParams.setContentCharset(params, "utf-8");
-    params.setBooleanParameter("http.protocol.expect-continue", false);
+    params.setBooleanParameter(CoreProtocolPNames.USE_EXPECT_CONTINUE, false);
+    params.setParameter(CoreProtocolPNames.USER_AGENT, "HockeySDK/Android");
   
     //registers schemes for both http and https
     SchemeRegistry registry = new SchemeRegistry();


### PR DESCRIPTION
Use ConnectionManager singleton when posting crash stacks.
Set the user agent header on the HTTP client globally.
