### PR TITLE
Use SSL Pinning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ buildscript {
     }
 }
 
+repositories {
+    mavenCentral()
+}
+
 version '3.5.0'
 group 'net.hockeyapp.android'
 
@@ -17,9 +21,23 @@ android {
     compileSdkVersion 17
     buildToolsVersion "19.1.0"
 
+    defaultConfig {
+        minSdkVersion 8
+        targetSdkVersion 19
+    }
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
+}
+
+dependencies {
+    compile 'org.thoughtcrime.ssl.pinning:AndroidPinning:1.0.0'
 }

--- a/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -259,7 +259,7 @@ public class CrashManager {
           if (stacktrace.length() > 0) {
             // Transmit stack trace with POST request
             Log.d(Constants.TAG, "Transmitting crash data: \n" + stacktrace);
-            DefaultHttpClient httpClient = (DefaultHttpClient)ConnectionManager.getInstance().getHttpClient();
+            DefaultHttpClient httpClient = (DefaultHttpClient)ConnectionManager.getInstance(weakContext.get()).getHttpClient();
             HttpPost httpPost = new HttpPost(getURLString());
             
             List <NameValuePair> parameters = new ArrayList <NameValuePair>(); 

--- a/src/main/java/net/hockeyapp/android/SSLPins.java
+++ b/src/main/java/net/hockeyapp/android/SSLPins.java
@@ -1,0 +1,16 @@
+package net.hockeyapp.android;
+
+/**
+ * A list of SSL Pins corresponding to certificates used by
+ * sdk.hockeyapp.net:443
+ *
+ * Created by davidbrodsky on 10/1/14.
+ */
+public class SSLPins {
+
+    public static String[] PINS = new String[] {
+        /** Equifax Secure CA */
+        "48e668f92bd2b295d747d82320104f3398909fd4"
+    };
+
+}

--- a/src/main/java/net/hockeyapp/android/tasks/LoginTask.java
+++ b/src/main/java/net/hockeyapp/android/tasks/LoginTask.java
@@ -127,7 +127,8 @@ public class LoginTask extends AsyncTask<Void, Void, Boolean> {
 
   @Override
   protected Boolean doInBackground(Void... args) {
-    HttpClient httpClient = ConnectionManager.getInstance().getHttpClient();
+    if (context == null) return false;
+    HttpClient httpClient = ConnectionManager.getInstance(context).getHttpClient();
 
     try {
       HttpUriRequest httpUriRequest = makeRequest(mode, params);

--- a/src/main/java/net/hockeyapp/android/tasks/SendFeedbackTask.java
+++ b/src/main/java/net/hockeyapp/android/tasks/SendFeedbackTask.java
@@ -148,7 +148,8 @@ public class SendFeedbackTask extends AsyncTask<Void, Void, HashMap<String, Stri
   
   @Override
   protected HashMap<String, String> doInBackground(Void... args) {
-    HttpClient httpclient = ConnectionManager.getInstance().getHttpClient();
+    if (context == null) return null;
+    HttpClient httpclient = ConnectionManager.getInstance(context).getHttpClient();
 
     if (isFetchMessages && token != null) {
       /** If we are fetching messages then do a GET */

--- a/src/main/java/net/hockeyapp/android/utils/ConnectionManager.java
+++ b/src/main/java/net/hockeyapp/android/utils/ConnectionManager.java
@@ -1,5 +1,9 @@
 package net.hockeyapp.android.utils;
 
+import android.content.Context;
+
+import net.hockeyapp.android.SSLPins;
+
 import org.apache.http.HttpVersion;
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.scheme.PlainSocketFactory;
@@ -12,17 +16,23 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.CoreProtocolPNames;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
+import org.thoughtcrime.ssl.pinning.PinningSSLSocketFactory;
+
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
 
 /**
  * <h3>Description</h3>
- * 
+ *
  * {@link HttpClient} manager class
- * 
+ *
  * <h3>License</h3>
- * 
+ *
  * <pre>
  * Copyright (c) 2011-2014 Bit Stadium GmbH
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -31,10 +41,10 @@ import org.apache.http.params.HttpProtocolParams;
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -44,42 +54,64 @@ import org.apache.http.params.HttpProtocolParams;
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  * </pre>
- * 
+ *
  * @author Bogdan Nistor
  */
 public class ConnectionManager {
   private HttpClient httpClient;
-  
+  private static ConnectionManager INSTANCE;
+
   /** Private constructor prevents instantiation from other classes */
-  private ConnectionManager() {
-    /** Sets up parameters */
-    HttpParams params = new BasicHttpParams();
-    HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
-    HttpProtocolParams.setContentCharset(params, "utf-8");
-    params.setBooleanParameter(CoreProtocolPNames.USE_EXPECT_CONTINUE, false);
-    params.setParameter(CoreProtocolPNames.USER_AGENT, "HockeySDK/Android");
-  
-    //registers schemes for both http and https
-    SchemeRegistry registry = new SchemeRegistry();
-    registry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
-    final SSLSocketFactory sslSocketFactory = SSLSocketFactory.getSocketFactory();
-    sslSocketFactory.setHostnameVerifier(SSLSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER);
-    registry.register(new Scheme("https", sslSocketFactory, 443));
-  
-    ThreadSafeClientConnManager manager = new ThreadSafeClientConnManager(params, registry);
-    httpClient = new DefaultHttpClient(manager, params);
+  private ConnectionManager(Context context) {
+      // Attempt to create a HttpClient with SSL Pinning
+      // but fallback to a standard trust model if that fails
+      // (which should never happen)
+      if (!createHttpClientWithPinningPreference(context, true)) {
+          createHttpClientWithPinningPreference(context, false);
+      }
   }
 
-  /**
-  * ConnectionManagerHolder is loaded on the first execution of ConnectionManager.getInstance() 
-  * or the first access to ConnectionManagerHolder.INSTANCE, not before.
-  */
-  private static class ConnectionManagerHolder { 
-    public static final ConnectionManager INSTANCE = new ConnectionManager();
+
+    /**
+     * Creates a {@link org.apache.http.client.HttpClient} optionally
+     * with SSL pinning.
+     *
+     * Returns whether the operation was successful
+     */
+  private boolean createHttpClientWithPinningPreference(Context context, boolean usePinning) {
+      /** Sets up parameters */
+      try {
+          HttpParams params = new BasicHttpParams();
+          HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
+          HttpProtocolParams.setContentCharset(params, "utf-8");
+          params.setBooleanParameter(CoreProtocolPNames.USE_EXPECT_CONTINUE, false);
+          params.setParameter(CoreProtocolPNames.USER_AGENT, "HockeySDK/Android");
+
+          //registers schemes for both http and https
+          SchemeRegistry registry = new SchemeRegistry();
+          registry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
+          final SSLSocketFactory sslSocketFactory = SSLSocketFactory.getSocketFactory();
+          sslSocketFactory.setHostnameVerifier(SSLSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER);
+          if (usePinning) {
+              registry.register(new Scheme("https", new PinningSSLSocketFactory(context, SSLPins.PINS, 0), 443));
+          } else {
+              registry.register(new Scheme("https", sslSocketFactory, 443));
+          }
+
+          ThreadSafeClientConnManager manager = new ThreadSafeClientConnManager(params, registry);
+          httpClient = new DefaultHttpClient(manager, params);
+          return true;
+      } catch (UnrecoverableKeyException | NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+          e.printStackTrace();
+      }
+      return false;
   }
 
-  public static ConnectionManager getInstance() {
-    return ConnectionManagerHolder.INSTANCE;
+  public static ConnectionManager getInstance(Context context) {
+    if (INSTANCE == null) {
+        INSTANCE = new ConnectionManager(context);
+    }
+    return INSTANCE;
   }
 
   public HttpClient getHttpClient() {


### PR DESCRIPTION
This is both a security and usability feature. Without this feature, security-sensitive applications that don't wish to trust the system CA store or have otherwise implemented custom SSLContexts may be unable to communicate with sdk.hockeyapp.net. As a bonus, the traffic between your customers (or is it your customers' customers :) ) and you isn't vulnerable to CA impersonation (it happens). 

The price for all this is the need to update the SDK with the pins of your new SSL certificate upon each renewal.

Used moxie's [AndroidPinning](https://github.com/moxie0/AndroidPinning) library.

Cheers! Love your work.
