### PR TITLE
Add method to enable in-app updates even if installed from market

### DIFF
--- a/src/main/java/net/hockeyapp/android/UpdateManager.java
+++ b/src/main/java/net/hockeyapp/android/UpdateManager.java
@@ -51,12 +51,6 @@ import android.text.TextUtils;
  * @author Thomas Dohmke
  **/
 public class UpdateManager {
-
-  /**
-   * Enable in-app updates even when downloaded from a market
-   */
-  private static boolean enableFromMarket = false;
-
   /**
    * Singleton for update task.
    */
@@ -119,7 +113,7 @@ public class UpdateManager {
       return;
     }
 
-    if ((!checkExpiryDate(weakActivity, listener)) && (enableFromMarket || !installedFromMarket(weakActivity))) {
+    if ((!checkExpiryDate(weakActivity, listener)) && (listener.canUpdateInMarket() || !installedFromMarket(weakActivity))) {
       startUpdateTask(weakActivity, urlString, appIdentifier, listener, isDialogRequired);
     }
   }
@@ -150,7 +144,7 @@ public class UpdateManager {
 
     WeakReference<Context> weakContext = new WeakReference<Context>(appContext);
 
-    if ((!checkExpiryDateForBackground(listener)) && (!installedFromMarket(weakContext))) {
+    if ((!checkExpiryDateForBackground(listener)) && (listener.canUpdateInMarket() || !installedFromMarket(weakContext))) {
       startUpdateTaskForBackground(weakContext, urlString, appIdentifier, listener);
     }
   }
@@ -289,15 +283,5 @@ public class UpdateManager {
    */
   public static UpdateManagerListener getLastListener() {
     return lastListener;
-  }
-
-  /**
-   * Enable updates even if installed from a market. Exercise caution with this, as some markets
-   * don't allow apps to update internally!
-   *
-   * Must be called before registering.
-   */
-  public static void enableUpdateFromMarket(boolean allow) {
-      enableFromMarket = allow;
   }
 }

--- a/src/main/java/net/hockeyapp/android/UpdateManagerListener.java
+++ b/src/main/java/net/hockeyapp/android/UpdateManagerListener.java
@@ -99,5 +99,13 @@ public abstract class UpdateManagerListener extends StringListener {
   public boolean onBuildExpired() {
     return true;
   }
+
+  /**
+   * To allow updates even if installed from a market, override this to return true.
+   * Exercise caution with this, as some markets' policies don't allow apps to update internally!
+   */
+  public boolean canUpdateInMarket() {
+      return false;
+  }
 }
   


### PR DESCRIPTION
The current implementation blocks this to prevent developers from accidentally leaving it on, but in turn also blocks developers from intentionally enabling it.

It's not the most attractive implementation (would prefer being able to chain the method, but `UsageEvent` doesn't contain an instance and I didn't want to change the API), but it's simple and makes itself available for developers that need it.

The new field is of course defaulted to `false`, again to ensure it doesn't change anything for existing users.

Please let me know what you guys think! Would really prefer to have first-party support for this rather than have to clone the SDK locally (as recommended [here](http://support.hockeyapp.net/discussions/questions/5646-is-it-possible-to-mix-using-hockeyapp-and-google-play-alphabeta-channels)).

``` java
private void checkForUpdates() {
   UpdateManager.enableUpdateFromMarket(true);
   UpdateManager.register(this, APP_ID);
 }
```
