### PR TITLE
Update UpdateActivity.java

### DIFF
--- a/src/main/java/net/hockeyapp/android/UpdateActivity.java
+++ b/src/main/java/net/hockeyapp/android/UpdateActivity.java
@@ -283,7 +283,7 @@ public class UpdateActivity extends Activity implements UpdateActivityInterface,
   @SuppressWarnings("deprecation")
   private boolean isUnknownSourcesChecked() {
     try {
-      if (android.os.Build.VERSION.SDK_INT >= 17) {
+      if (android.os.Build.VERSION.SDK_INT >= 17 && android.os.Build.VERSION.SDK_INT < 21) {
         return (Settings.Global.getInt(getContentResolver(), Settings.Global.INSTALL_NON_MARKET_APPS) == 1);
       }
       else {


### PR DESCRIPTION
Settings.Secure.INSTALL_NON_MARKET_APPS has changed from deprecated to undeprecated (deprecating Settings.Global.INSTALL_NON_MARKET_APPS) in API 21: https://developer.android.com/sdk/api_diff/21/changes/android.provider.Settings.Secure.html

Without this change, Android 5.0 cannot install updates from UpdateActivity
