### PR TITLE
Fix: Crash dialog neutral button text is not loaded from resources.

### DIFF
--- a/src/main/java/net/hockeyapp/android/LocaleManager.java
+++ b/src/main/java/net/hockeyapp/android/LocaleManager.java
@@ -49,6 +49,7 @@ public class LocaleManager {
     loadFromResources("hockeyapp_crash_dialog_title", Strings.CRASH_DIALOG_TITLE_ID, context);
     loadFromResources("hockeyapp_crash_dialog_message", Strings.CRASH_DIALOG_MESSAGE_ID, context);
     loadFromResources("hockeyapp_crash_dialog_negative_button", Strings.CRASH_DIALOG_NEGATIVE_BUTTON_ID, context);
+    loadFromResources("hockeyapp_crash_dialog_neutral_button", Strings.CRASH_DIALOG_NEUTRAL_BUTTON_ID, context);
     loadFromResources("hockeyapp_crash_dialog_positive_button", Strings.CRASH_DIALOG_POSITIVE_BUTTON_ID, context);
 
     // Download Failed


### PR DESCRIPTION
I think the neutral button of the crash dialog was omitted. Simply added the missing loadFromResources method call.