### PR TITLE
Fix: mandatory updates for older than current versions not working

### DIFF
--- a/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTask.java
+++ b/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTask.java
@@ -158,6 +158,8 @@ public class CheckUpdateTask extends AsyncTask<Void, String, JSONArray>{
 
   private boolean findNewVersion(JSONArray json, int versionCode) {
     try {
+	  boolean newerVersionFound = false;
+
       for (int index = 0; index < json.length(); index++) {
         JSONObject entry = json.getJSONObject(index);
 
@@ -167,13 +169,13 @@ public class CheckUpdateTask extends AsyncTask<Void, String, JSONArray>{
 
         if ((largerVersionCode || newerApkFile) && minRequirementsMet) {
           if (entry.has("mandatory")) {
-            mandatory = entry.getBoolean("mandatory");
+            mandatory |= entry.getBoolean("mandatory");
           }
-          return true;
+          newerVersionFound = true;
         }
       }
       
-      return false;
+      return newerVersionFound;
     }
     catch (JSONException e) {
       return false;


### PR DESCRIPTION
Mandatory updates are not mandatory if an older version is set as mandatory because findNewVersion returns as soon as a newer version is found.