### PR TITLE
Add logic to limit retry attempts to try and upload dump to hockey backend

### DIFF
--- a/src/main/java/net/hockeyapp/android/CrashManagerListener.java
+++ b/src/main/java/net/hockeyapp/android/CrashManagerListener.java
@@ -152,4 +152,12 @@ public abstract class CrashManagerListener extends StringListener {
    */
   public void onUserDeniedCrashes() {
   }
+
+  /**
+   * Get the number of max retry attempts to send crashes to HockeyApp.
+   * Infinite retries if this value is set to -1
+   */
+  public int getMaxRetryAttempts() {
+      return -1;
+  }
 }


### PR DESCRIPTION
Logic to limit retry attempts to try to upload stacktrace to hockey. Currently, there is no limit to retry uploading to hockey. So, on every launch all the dumps are tried to get uploaded.
With the new change, setting maxRetryAttempt to -1 achieves this behavior and this is the default value.