### PR TITLE
Replace version mapping with detecting prerelease versions

### DIFF
--- a/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTask.java
+++ b/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTask.java
@@ -165,7 +165,7 @@ public class CheckUpdateTask extends AsyncTask<Void, String, JSONArray>{
 
         boolean largerVersionCode = (entry.getInt("version") > versionCode);
         boolean newerApkFile = ((entry.getInt("version") == versionCode) && VersionHelper.isNewerThanLastUpdateTime(context, entry.getLong("timestamp")));
-        boolean minRequirementsMet = VersionHelper.isAndroidPreReleaseVersion(Build.VERSION.RELEASE) || VersionHelper.compareVersionStrings(entry.getString("minimum_os_version"), Build.VERSION.RELEASE) <= 0;
+        boolean minRequirementsMet = VersionHelper.compareVersionStrings(entry.getString("minimum_os_version"), VersionHelper.mapGoogleVersion(Build.VERSION.RELEASE)) <= 0;
 
         if ((largerVersionCode || newerApkFile) && minRequirementsMet) {
           if (entry.has("mandatory")) {

--- a/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTask.java
+++ b/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTask.java
@@ -165,7 +165,7 @@ public class CheckUpdateTask extends AsyncTask<Void, String, JSONArray>{
 
         boolean largerVersionCode = (entry.getInt("version") > versionCode);
         boolean newerApkFile = ((entry.getInt("version") == versionCode) && VersionHelper.isNewerThanLastUpdateTime(context, entry.getLong("timestamp")));
-        boolean minRequirementsMet = VersionHelper.compareVersionStrings(entry.getString("minimum_os_version"), VersionHelper.mapGoogleVersion(Build.VERSION.RELEASE)) <= 0;
+        boolean minRequirementsMet = VersionHelper.isAndroidPreReleaseVersion(Build.VERSION.RELEASE) || VersionHelper.compareVersionStrings(entry.getString("minimum_os_version"), Build.VERSION.RELEASE) <= 0;
 
         if ((largerVersionCode || newerApkFile) && minRequirementsMet) {
           if (entry.has("mandatory")) {

--- a/src/main/java/net/hockeyapp/android/utils/VersionHelper.java
+++ b/src/main/java/net/hockeyapp/android/utils/VersionHelper.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.Scanner;
+import java.util.regex.Pattern;
 
 import net.hockeyapp.android.UpdateInfoListener;
 
@@ -344,18 +345,12 @@ public class VersionHelper {
   }
 
   /**
-   * Map internal Google version letter to a semantic version (currently L to 5.0).
+   * Detect Android pre-release versions (currently null or single-letter version names).
    *
-   * @param version value of Build.VERSION.RELEASE
-   * @return mapped version number
+   * @param version
+   * @return true if the version indicates an Android pre-release version
    */
-  public static String mapGoogleVersion(String version) {
-    if ((version == null) || (version.equalsIgnoreCase("L"))) {
-      return "5.0";
-    } else if (version.equalsIgnoreCase("M")) {
-      return "6.0";
-    } else {
-      return version;
-    }
+  public static boolean isAndroidPreReleaseVersion(String version) {
+    return version == null || Pattern.matches("[a-zA-Z]", version);
   }
 }

--- a/src/main/java/net/hockeyapp/android/utils/VersionHelper.java
+++ b/src/main/java/net/hockeyapp/android/utils/VersionHelper.java
@@ -1,23 +1,17 @@
 package net.hockeyapp.android.utils;
 
-import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.Scanner;
-import java.util.regex.Pattern;
-
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import net.hockeyapp.android.UpdateInfoListener;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.content.Context;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * <h3>Description</h3>
@@ -55,6 +49,8 @@ import android.content.pm.PackageManager;
  * @author Thomas Dohmke
  **/
 public class VersionHelper {
+  public static final String VERSION_MAX = "99.0";
+
   private ArrayList<JSONObject> sortedVersions;
   private JSONObject newest;
   private UpdateInfoListener listener;
@@ -345,12 +341,23 @@ public class VersionHelper {
   }
 
   /**
-   * Detect Android pre-release versions (currently null or single-letter version names).
+   * Map internal Google version letter to a semantic version (currently L to 5.0, M to 6.0).
+   * All other pre release versions (versions consisting of only letters) will return VERSION_MAX,
+   * to indicate they are newer, to prevent having new releases of the SDK with every Android
+   * pre release.
    *
-   * @param version
-   * @return true if the version indicates an Android pre-release version
+   * @param version value of Build.VERSION.RELEASE
+   * @return mapped version number
    */
-  public static boolean isAndroidPreReleaseVersion(String version) {
-    return version == null || Pattern.matches("[a-zA-Z]", version);
+  public static String mapGoogleVersion(String version) {
+    if ((version == null) || (version.equalsIgnoreCase("L"))) {
+      return "5.0";
+    } else if (version.equalsIgnoreCase("M")) {
+      return "6.0";
+    } else if (Pattern.matches("[a-zA-Z]+", version)) {
+      return VERSION_MAX;
+    } else {
+      return version;
+    }
   }
 }


### PR DESCRIPTION
Pre-Releases are indicated by having a single letter as the version name.
This way we (and SDK users) won't have to update with every new pre-release.