### PR TITLE
Fix Attach Image for freedback on Android and update versions

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest 
     xmlns:android="http://schemas.android.com/apk/res/android"
 	package="net.hockeyapp.android">
+
+    <uses-sdk android:minSdkVersion="11" android:targetSdkVersion="22"/>
     
     <application>
 
@@ -11,7 +13,5 @@
             android:windowSoftInputMode="stateAlwaysHidden|adjustPan"/>
 
     </application>
-
-    <uses-sdk android:minSdkVersion="7" android:targetSdkVersion="13"/>
     
 </manifest> 

--- a/build.gradle
+++ b/build.gradle
@@ -4,22 +4,39 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 
-version '3.5.0'
+version '3.5.1'
 group 'net.hockeyapp.android'
 
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
         }
     }
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+task jar(type: Jar) {
+    from 'build/intermediates/classes/release'
+    exclude '**/BuildConfig.class'
+    exclude '**/R.class'
+    exclude 'de/keyboardsurfer/mobile/'
+}
+
+artifacts {
+    archives sourcesJar
+    archives jar
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 04 19:18:35 CEST 2013
+#Tue Aug 18 09:57:28 BST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip

--- a/src/main/java/net/hockeyapp/android/FeedbackActivity.java
+++ b/src/main/java/net/hockeyapp/android/FeedbackActivity.java
@@ -398,29 +398,13 @@ public class FeedbackActivity extends Activity implements FeedbackActivityInterf
       return;
     }
 
-    if (requestCode == ATTACH_FILE) {
+    if (requestCode == ATTACH_FILE || requestCode == ATTACH_PICTURE) {
       /** User picked file */
       Uri uri = data.getData();
 
       if (uri != null) {
         final ViewGroup attachments = (ViewGroup) findViewById(FeedbackView.WRAPPER_LAYOUT_ATTACHMENTS);
         attachments.addView(new AttachmentView(this, attachments, uri, true));
-      }
-
-    } else if (requestCode == ATTACH_PICTURE) {
-      /** User picked image */
-      Uri uri = data.getData();
-
-      /** Start PaintActivity */
-      if (uri != null) {
-        try {
-          Intent intent = new Intent(this, PaintActivity.class);
-          intent.putExtra("imageUri", uri);
-          startActivityForResult(intent, PAINT_IMAGE);
-        } catch (ActivityNotFoundException e) {
-          Log.e(Util.LOG_IDENTIFIER, "Paint activity not declared!", e);
-        }
-
       }
 
     } else if (requestCode == PAINT_IMAGE) {


### PR DESCRIPTION
Using https://github.com/peutetre/cordova-plugin-hockeyapp on Android under the Feedback Scrren the 'Add Attachment' -> 'Attach Picture' functionality is broken on Nexus 5, Android 5.1. It opens the image chooser but when you select the image nothing happens.

When you click Attach File and choose a picture it adds the picture fine and also renders a preview of the picture. So I just made the 'select picture' functionality more closely match the 'attach file' functionality.

Furthermore I just built this with the latest Android Studio etc. which needed https://github.com/bitstadium/HockeySDK-Android/pull/48 to also build the jar file necessary for the cordova plugin.

I already bumped the version, let me know if you want anything changed.