### PR TITLE
Updating HockeyApp SDK to be built with latest SDK with updated dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,22 +4,24 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
-
 version '3.5.0'
 group 'net.hockeyapp.android'
-
 apply plugin: 'android-library'
-
 android {
-    compileSdkVersion 17
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.0"
+    useLibrary 'org.apache.http.legacy'
 
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
         }
     }
+}
+
+dependencies {
+    compile 'com.android.support:support-v4:23.0.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 04 19:18:35 CEST 2013
+#Tue Sep 01 08:30:01 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip

--- a/src/main/java/net/hockeyapp/android/FeedbackManager.java
+++ b/src/main/java/net/hockeyapp/android/FeedbackManager.java
@@ -15,9 +15,11 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
+
 import net.hockeyapp.android.objects.FeedbackUserDataElement;
 import net.hockeyapp.android.tasks.ParseFeedbackTask;
 import net.hockeyapp.android.tasks.SendFeedbackTask;
@@ -356,13 +358,20 @@ public class FeedbackManager {
 
     NotificationManager notificationManager = (NotificationManager) currentActivity.getSystemService(Context.NOTIFICATION_SERVICE);
 
-    int iconId = currentActivity.getResources().getIdentifier("ic_menu_camera", "drawable", "android");
-    Notification notification = new Notification(iconId, "", System.currentTimeMillis());
+
 
     Intent intent =  new Intent();
     intent.setAction(BROADCAST_ACTION);
     PendingIntent pendingIntent = PendingIntent.getBroadcast(currentActivity, BROADCAST_REQUEST_CODE, intent, PendingIntent.FLAG_ONE_SHOT);
-    notification.setLatestEventInfo(currentActivity, "HockeyApp Feedback", "Take a screenshot for your feedback.", pendingIntent);
+    int iconId = currentActivity.getResources().getIdentifier("ic_menu_camera", "drawable", "android");
+    Notification notification = new NotificationCompat.Builder(currentActivity)
+            .setTicker("")
+            .setSmallIcon(iconId)
+            .setWhen(System.currentTimeMillis())
+            .setContentTitle("HockeyApp Feedback")
+            .setContentText("Take a screenshot for your feedback.")
+            .setContentIntent(pendingIntent)
+            .build();
     notificationManager.notify(SCREENSHOT_NOTIFICATION_ID, notification);
 
     if (receiver == null) {

--- a/src/main/java/net/hockeyapp/android/tasks/ParseFeedbackTask.java
+++ b/src/main/java/net/hockeyapp/android/tasks/ParseFeedbackTask.java
@@ -10,6 +10,8 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.support.v4.app.NotificationCompat;
+
 import net.hockeyapp.android.FeedbackActivity;
 import net.hockeyapp.android.FeedbackManager;
 import net.hockeyapp.android.FeedbackManagerListener;
@@ -154,7 +156,6 @@ public class ParseFeedbackTask extends AsyncTask<Void, Void, FeedbackResponse> {
 
     NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
     int iconId = context.getResources().getIdentifier("ic_menu_refresh", "drawable", "android");
-    Notification notification = new Notification(iconId, "New Answer to Your Feedback.", System.currentTimeMillis());
 
     Class<?> activityClass = null;
     if (FeedbackManager.getLastListener() != null) {
@@ -170,7 +171,14 @@ public class ParseFeedbackTask extends AsyncTask<Void, Void, FeedbackResponse> {
     intent.putExtra("url", urlString);
 
     PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_ONE_SHOT);
-    notification.setLatestEventInfo(context, "HockeyApp Feedback", "A new answer to your feedback is available.", pendingIntent);
+    Notification notification = new NotificationCompat.Builder(context)
+            .setWhen(System.currentTimeMillis())
+            .setSmallIcon(iconId)
+            .setTicker("New Answer to Your Feedback.")
+            .setContentTitle("HockeyApp Feedback")
+            .setContentText("A new answer to your feedback is available.")
+            .setContentIntent(pendingIntent).build();
+
     notificationManager.notify(NEW_ANSWER_NOTIFICATION_ID, notification);
   }
 }


### PR DESCRIPTION
I noticed that this Library used Apache Http Client (which in the latest SDK is 100% deprecated, and removed). I understand that updating the app to use another http client library would introduce some risk. So this is just to make it so that the dependencies of this library are declared accordingly and to make suer client applications do not have to consciously include Apache HttpClient if it is not needed. Otherwise in the event that this library does migrate to another Http implementation, the applications using this library would still be including the legacy library without any need.