### PR TITLE
Add extras to FeedbackActivity through FeedbackManager.showFeedbackActivity

### DIFF
--- a/src/main/java/net/hockeyapp/android/FeedbackManager.java
+++ b/src/main/java/net/hockeyapp/android/FeedbackManager.java
@@ -152,7 +152,7 @@ public class FeedbackManager {
       FeedbackManager.identifier = Util.sanitizeAppIdentifier(appIdentifier);
       FeedbackManager.urlString = urlString;
       FeedbackManager.lastListener = listener;
-    
+
       Constants.loadFromContext(context);
     }
   }
@@ -170,6 +170,15 @@ public class FeedbackManager {
    * @param attachments the optional attachment {@link Uri}s
    */
   public static void showFeedbackActivity(Context context, Uri... attachments) {
+    showFeedbackActivity(context, null, attachments);
+  }
+  /**
+   * Starts the {@link FeedbackActivity}
+   * @param context {@link Context} object
+   * @param attachments the optional attachment {@link Uri}s
+   * @param extras a bundle to be added to the Intent that starts the FeedbackActivity instance
+   */
+  public static void showFeedbackActivity(Context context, Bundle extras, Uri... attachments) {
     if (context != null) {
       Class<?> activityClass = null;
       if (lastListener != null) {
@@ -180,6 +189,9 @@ public class FeedbackManager {
       }
       
       Intent intent = new Intent();
+      if (extras != null && !extras.isEmpty()) {
+        intent.putExtras(extras);
+      }
       intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       intent.setClass(context, activityClass);
       intent.putExtra("url", getURLString(context));


### PR DESCRIPTION
I find it useful to add some extras to the FeedbackActivity started by FeedbackManager. that way if one uses her own subclass of FeedbackActivity and override onSendFeedbackResult, he may access those extras.
For example - say you implement a policy that governs the times/features to ask for feedback, and you wish to update the model for that policy once the user provided feedback. The extras would be a way to carry relevant details from the FeedbackManager.showFeedbackActivity towards the call to onSendFeedbackResult