### PR TITLE
Add missing call to super in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ import net.hockeyapp.android.UpdateManager;
 public class YourActivity extends Activity {
   @Override
   public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
     // Your own code to create the view
     // ...
     


### PR DESCRIPTION
Add missing call to super.onCreate() in the readme "hello world"
example. Since this example is meant to copy and paste work in a dummy
app, and the other overrides call the super, it's worth explicitly
calling the super in onCreate() too.