### PR TITLE
Update autosend example

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,13 +206,13 @@ To configure a custom `CrashManagerListener` use the following `register()` meth
 
 #### 3.3.1 Autosend crash reports
 
-Crashes are send the next time the app starts. If your custom crash manager listener returns `true` for `onCrashesFound()`, crashes will be send without any user interaction, otherwise a dialog will appear allowing the user to decide whether they want to send the report or not.
+Crashes are sent the next time the app starts. If your custom crash manager listener returns `true` for `shouldAutoUploadCrashes()`, crashes will be sent without any user interaction, otherwise a dialog will appear allowing the user to decide whether they want to send the report or not.
 
 ```java
 
-public class MyCustomCrashManagerListener {
+public class MyCustomCrashManagerListener extends CrashManagerListener {
   @Override
-  public boolean onCrashesFound() {
+  public boolean shouldAutoUploadCrashes() {
     return true;
   }
 }


### PR DESCRIPTION
- Fix missing class hierarchy to extend from CrashManagerListener.
- Override shouldAutoUploadCrashReport() instead of the deprecated
  onCrashesFound().
- Minor adjustments to word tense.