### PR TITLE
Add thread details upon crash if available

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManagerListener.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManagerListener.java
@@ -67,6 +67,15 @@ public abstract class CrashManagerListener {
   }
 
   /**
+   * Return true to include information about the crashed thread if available.
+   *
+   * @return if true, the crash report will include thread id and name if available
+   */
+  public boolean includeThreadDetails() {
+    return true;
+  }
+
+  /**
    * Return contact data or similar; note that this has privacy implications,
    * so you might want to return nil for release builds! The string will be
    * limited to 255 characters.

--- a/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
@@ -66,8 +66,13 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
   public void setListener(CrashManagerListener listener) {
     this.listener = listener;
   }
-  
+
+  @Deprecated
   public static void saveException(Throwable exception, CrashManagerListener listener) {
+    saveException(exception, null, listener);
+  }
+  
+  public static void saveException(Throwable exception, Thread thread, CrashManagerListener listener) {
     final Date now = new Date();
     final Writer result = new StringWriter();
     final PrintWriter printWriter = new PrintWriter(result);
@@ -92,6 +97,10 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
         write.write("Android: " + Constants.ANDROID_VERSION + "\n");
         write.write("Manufacturer: " + Constants.PHONE_MANUFACTURER + "\n");
         write.write("Model: " + Constants.PHONE_MODEL + "\n");
+      }
+
+      if (thread != null && ((listener == null) || (listener.includeThreadDetails()))) {
+        write.write("Thread: " + thread.getName() + "-" + thread.getId() + "\n");
       }
       
       if (Constants.CRASH_IDENTIFIER != null && (listener == null || listener.includeDeviceIdentifier())) {
@@ -122,7 +131,7 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
       defaultExceptionHandler.uncaughtException(thread, exception);
     }
     else {
-      saveException(exception, listener);
+      saveException(exception, thread, listener);
 
       if (!ignoreDefaultHandler) {
         defaultExceptionHandler.uncaughtException(thread, exception);


### PR DESCRIPTION
Fixes #102 by adding thread name and id to crash report when available.
CrashManagerListener can override behavior but default is to include crashed thread information.