### PR TITLE
Added wrapper for log output

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
@@ -135,7 +135,7 @@ public class Constants {
         File dir = new File(externalStorage.getAbsolutePath() + "/" + Constants.TAG);
         Boolean success = dir.mkdirs();
         if (!success) {
-            HockeyLog.log("Couldn't create HockeyApp Storage dir");
+            HockeyLog.warn("Couldn't create HockeyApp Storage dir");
         }
         return dir;
     }
@@ -183,7 +183,7 @@ public class Constants {
                     Constants.APP_VERSION = "" + buildNumber;
                 }
             } catch (PackageManager.NameNotFoundException e) {
-                Log.e(TAG, "Exception thrown when accessing the package info:");
+                HockeyLog.error(TAG, "Exception thrown when accessing the package info:");
                 e.printStackTrace();
             }
         }
@@ -203,7 +203,7 @@ public class Constants {
                 return metaData.getInt(BUNDLE_BUILD_NUMBER, 0);
             }
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e(TAG, "Exception thrown when accessing the application info:");
+            HockeyLog.error(TAG, "Exception thrown when accessing the application info:");
             e.printStackTrace();
         }
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
@@ -11,6 +11,8 @@ import android.os.Environment;
 import android.provider.Settings;
 import android.util.Log;
 
+import net.hockeyapp.android.utils.HockeyLog;
+
 import java.io.File;
 import java.security.MessageDigest;
 
@@ -133,7 +135,7 @@ public class Constants {
         File dir = new File(externalStorage.getAbsolutePath() + "/" + Constants.TAG);
         Boolean success = dir.mkdirs();
         if (!success) {
-            Log.d(TAG, "Couldn't create HockeyApp Storage dir");
+            HockeyLog.log("Couldn't create HockeyApp Storage dir");
         }
         return dir;
     }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -7,10 +7,10 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.preference.PreferenceManager;
-import android.util.Log;
 
 import net.hockeyapp.android.objects.CrashManagerUserInput;
 import net.hockeyapp.android.objects.CrashMetaData;
+import net.hockeyapp.android.utils.HockeyLog;
 import net.hockeyapp.android.utils.HttpURLConnectionBuilder;
 import net.hockeyapp.android.utils.Util;
 
@@ -280,7 +280,7 @@ public class CrashManager {
         Boolean successful = false;
 
         if ((list != null) && (list.length > 0)) {
-            Log.d(Constants.TAG, "Found " + list.length + " stacktrace(s).");
+            HockeyLog.log(Constants.TAG, "Found " + list.length + " stacktrace(s).");
 
             for (int index = 0; index < list.length; index++) {
                 HttpURLConnection urlConnection = null;
@@ -291,7 +291,7 @@ public class CrashManager {
                     if (stacktrace.length() > 0) {
                         // Transmit stack trace with POST request
 
-                        Log.d(Constants.TAG, "Transmitting crash data: \n" + stacktrace);
+                        HockeyLog.log(Constants.TAG, "Transmitting crash data: \n" + stacktrace);
 
                         // Retrieve user ID and contact information if given
                         String userID = contentsOfFile(weakContext, filename.replace(".stacktrace", ".user"));
@@ -345,7 +345,7 @@ public class CrashManager {
                         urlConnection.disconnect();
                     }
                     if (successful) {
-                        Log.d(Constants.TAG, "Transmission succeeded");
+                        HockeyLog.log(Constants.TAG, "Transmission succeeded");
                         deleteStackTrace(weakContext, list[index]);
 
                         if (listener != null) {
@@ -353,7 +353,7 @@ public class CrashManager {
                             deleteRetryCounter(weakContext, list[index], listener.getMaxRetryAttempts());
                         }
                     } else {
-                        Log.d(Constants.TAG, "Transmission failed, will retry on next register() call");
+                        HockeyLog.log(Constants.TAG, "Transmission failed, will retry on next register() call");
                         if (listener != null) {
                             listener.onCrashesNotSent();
                             updateRetryCounter(weakContext, list[index], listener.getMaxRetryAttempts());
@@ -373,13 +373,13 @@ public class CrashManager {
         String[] list = searchForStackTraces();
 
         if ((list != null) && (list.length > 0)) {
-            Log.d(Constants.TAG, "Found " + list.length + " stacktrace(s).");
+            HockeyLog.log(Constants.TAG, "Found " + list.length + " stacktrace(s).");
 
             for (int index = 0; index < list.length; index++) {
                 try {
                     Context context = null;
                     if (weakContext != null) {
-                        Log.d(Constants.TAG, "Delete stacktrace " + list[index] + ".");
+                        HockeyLog.log(Constants.TAG, "Delete stacktrace " + list[index] + ".");
                         deleteStackTrace(weakContext, list[index]);
 
                         context = weakContext.get();
@@ -581,7 +581,7 @@ public class CrashManager {
             // Get current handler
             UncaughtExceptionHandler currentHandler = Thread.getDefaultUncaughtExceptionHandler();
             if (currentHandler != null) {
-                Log.d(Constants.TAG, "Current handler class = " + currentHandler.getClass().getName());
+                HockeyLog.log(Constants.TAG, "Current handler class = " + currentHandler.getClass().getName());
             }
 
             // Update listener if already registered, otherwise set new handler
@@ -591,7 +591,7 @@ public class CrashManager {
                 Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler(currentHandler, listener, ignoreDefaultHandler));
             }
         } else {
-            Log.d(Constants.TAG, "Exception handler not set because version or package is null.");
+            HockeyLog.log(Constants.TAG, "Exception handler not set because version or package is null.");
         }
     }
 
@@ -746,7 +746,7 @@ public class CrashManager {
      */
     private static String[] searchForStackTraces() {
         if (Constants.FILES_PATH != null) {
-            Log.d(Constants.TAG, "Looking for exceptions in: " + Constants.FILES_PATH);
+            HockeyLog.log(Constants.TAG, "Looking for exceptions in: " + Constants.FILES_PATH);
 
             // Try to create the files folder if it doesn't exist
             File dir = new File(Constants.FILES_PATH + "/");
@@ -763,7 +763,7 @@ public class CrashManager {
             };
             return dir.list(filter);
         } else {
-            Log.d(Constants.TAG, "Can't search for exception as file path is null.");
+            HockeyLog.log(Constants.TAG, "Can't search for exception as file path is null.");
             return null;
         }
     }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -280,7 +280,7 @@ public class CrashManager {
         Boolean successful = false;
 
         if ((list != null) && (list.length > 0)) {
-            HockeyLog.log(Constants.TAG, "Found " + list.length + " stacktrace(s).");
+            HockeyLog.debug(Constants.TAG, "Found " + list.length + " stacktrace(s).");
 
             for (int index = 0; index < list.length; index++) {
                 HttpURLConnection urlConnection = null;
@@ -291,7 +291,7 @@ public class CrashManager {
                     if (stacktrace.length() > 0) {
                         // Transmit stack trace with POST request
 
-                        HockeyLog.log(Constants.TAG, "Transmitting crash data: \n" + stacktrace);
+                        HockeyLog.debug(Constants.TAG, "Transmitting crash data: \n" + stacktrace);
 
                         // Retrieve user ID and contact information if given
                         String userID = contentsOfFile(weakContext, filename.replace(".stacktrace", ".user"));
@@ -345,7 +345,7 @@ public class CrashManager {
                         urlConnection.disconnect();
                     }
                     if (successful) {
-                        HockeyLog.log(Constants.TAG, "Transmission succeeded");
+                        HockeyLog.debug(Constants.TAG, "Transmission succeeded");
                         deleteStackTrace(weakContext, list[index]);
 
                         if (listener != null) {
@@ -353,7 +353,7 @@ public class CrashManager {
                             deleteRetryCounter(weakContext, list[index], listener.getMaxRetryAttempts());
                         }
                     } else {
-                        HockeyLog.log(Constants.TAG, "Transmission failed, will retry on next register() call");
+                        HockeyLog.debug(Constants.TAG, "Transmission failed, will retry on next register() call");
                         if (listener != null) {
                             listener.onCrashesNotSent();
                             updateRetryCounter(weakContext, list[index], listener.getMaxRetryAttempts());
@@ -373,13 +373,13 @@ public class CrashManager {
         String[] list = searchForStackTraces();
 
         if ((list != null) && (list.length > 0)) {
-            HockeyLog.log(Constants.TAG, "Found " + list.length + " stacktrace(s).");
+            HockeyLog.debug(Constants.TAG, "Found " + list.length + " stacktrace(s).");
 
             for (int index = 0; index < list.length; index++) {
                 try {
                     Context context = null;
                     if (weakContext != null) {
-                        HockeyLog.log(Constants.TAG, "Delete stacktrace " + list[index] + ".");
+                        HockeyLog.debug(Constants.TAG, "Delete stacktrace " + list[index] + ".");
                         deleteStackTrace(weakContext, list[index]);
 
                         context = weakContext.get();
@@ -581,7 +581,7 @@ public class CrashManager {
             // Get current handler
             UncaughtExceptionHandler currentHandler = Thread.getDefaultUncaughtExceptionHandler();
             if (currentHandler != null) {
-                HockeyLog.log(Constants.TAG, "Current handler class = " + currentHandler.getClass().getName());
+                HockeyLog.debug(Constants.TAG, "Current handler class = " + currentHandler.getClass().getName());
             }
 
             // Update listener if already registered, otherwise set new handler
@@ -591,7 +591,7 @@ public class CrashManager {
                 Thread.setDefaultUncaughtExceptionHandler(new ExceptionHandler(currentHandler, listener, ignoreDefaultHandler));
             }
         } else {
-            HockeyLog.log(Constants.TAG, "Exception handler not set because version or package is null.");
+            HockeyLog.debug(Constants.TAG, "Exception handler not set because version or package is null.");
         }
     }
 
@@ -746,7 +746,7 @@ public class CrashManager {
      */
     private static String[] searchForStackTraces() {
         if (Constants.FILES_PATH != null) {
-            HockeyLog.log(Constants.TAG, "Looking for exceptions in: " + Constants.FILES_PATH);
+            HockeyLog.debug(Constants.TAG, "Looking for exceptions in: " + Constants.FILES_PATH);
 
             // Try to create the files folder if it doesn't exist
             File dir = new File(Constants.FILES_PATH + "/");
@@ -763,7 +763,7 @@ public class CrashManager {
             };
             return dir.list(filter);
         } else {
-            HockeyLog.log(Constants.TAG, "Can't search for exception as file path is null.");
+            HockeyLog.debug(Constants.TAG, "Can't search for exception as file path is null.");
             return null;
         }
     }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
@@ -1,7 +1,6 @@
 package net.hockeyapp.android;
 
 import android.text.TextUtils;
-import android.util.Log;
 
 import net.hockeyapp.android.utils.HockeyLog;
 
@@ -104,7 +103,7 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
             // Create filename from a random uuid
             String filename = UUID.randomUUID().toString();
             String path = Constants.FILES_PATH + "/" + filename + ".stacktrace";
-            HockeyLog.log(Constants.TAG, "Writing unhandled exception to: " + path);
+            HockeyLog.debug(Constants.TAG, "Writing unhandled exception to: " + path);
 
             // Write the stacktrace to disk
             writer = new BufferedWriter(new FileWriter(path));
@@ -139,14 +138,14 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
                 writeValueToFile(listener.getDescription(), filename + ".description");
             }
         } catch (IOException another) {
-            Log.e(Constants.TAG, "Error saving exception stacktrace!\n", another);
+            HockeyLog.error(Constants.TAG, "Error saving exception stacktrace!\n", another);
         } finally {
             try {
                 if (writer != null) {
                     writer.close();
                 }
             } catch (IOException e) {
-                Log.e(Constants.TAG, "Error saving exception stacktrace!\n", e);
+                HockeyLog.error(Constants.TAG, "Error saving exception stacktrace!\n", e);
                 e.printStackTrace();
             }
         }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
@@ -3,6 +3,8 @@ package net.hockeyapp.android;
 import android.text.TextUtils;
 import android.util.Log;
 
+import net.hockeyapp.android.utils.HockeyLog;
+
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -102,7 +104,7 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
             // Create filename from a random uuid
             String filename = UUID.randomUUID().toString();
             String path = Constants.FILES_PATH + "/" + filename + ".stacktrace";
-            Log.d(Constants.TAG, "Writing unhandled exception to: " + path);
+            HockeyLog.log(Constants.TAG, "Writing unhandled exception to: " + path);
 
             // Write the stacktrace to disk
             writer = new BufferedWriter(new FileWriter(path));

--- a/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
@@ -17,7 +17,6 @@ import android.os.Handler;
 import android.os.Message;
 import android.os.Parcelable;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.ContextMenu;
 import android.view.KeyEvent;
 import android.view.MenuItem;
@@ -41,6 +40,7 @@ import net.hockeyapp.android.objects.FeedbackUserDataElement;
 import net.hockeyapp.android.tasks.ParseFeedbackTask;
 import net.hockeyapp.android.tasks.SendFeedbackTask;
 import net.hockeyapp.android.utils.AsyncTaskUtils;
+import net.hockeyapp.android.utils.HockeyLog;
 import net.hockeyapp.android.utils.PrefsUtil;
 import net.hockeyapp.android.utils.Util;
 import net.hockeyapp.android.views.AttachmentListView;
@@ -444,7 +444,7 @@ public class FeedbackActivity extends Activity implements OnClickListener {
                     intent.putExtra(PaintActivity.EXTRA_IMAGE_URI, uri);
                     startActivityForResult(intent, PAINT_IMAGE);
                 } catch (ActivityNotFoundException e) {
-                    Log.e(Util.LOG_IDENTIFIER, "Paint activity not declared!", e);
+                    HockeyLog.error(Util.LOG_IDENTIFIER, "Paint activity not declared!", e);
                 }
 
             }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackManager.java
@@ -23,6 +23,7 @@ import net.hockeyapp.android.objects.FeedbackUserDataElement;
 import net.hockeyapp.android.tasks.ParseFeedbackTask;
 import net.hockeyapp.android.tasks.SendFeedbackTask;
 import net.hockeyapp.android.utils.AsyncTaskUtils;
+import net.hockeyapp.android.utils.HockeyLog;
 import net.hockeyapp.android.utils.PrefsUtil;
 import net.hockeyapp.android.utils.Util;
 
@@ -389,7 +390,7 @@ public class FeedbackManager {
                     out.close();
                     return true;
                 } catch (IOException e) {
-                    Log.e(Constants.TAG, "Could not save screenshot.", e);
+                    HockeyLog.error(Constants.TAG, "Could not save screenshot.", e);
                 }
                 return false;
             }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/PaintActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/PaintActivity.java
@@ -12,7 +12,6 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.MediaStore;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -65,7 +64,7 @@ public class PaintActivity extends Activity {
 
         if (currentOrientation != desiredOrientation) {
       /* Activity will be destroyed again.. skip the following expensive operations. */
-            HockeyLog.log(Constants.TAG, "Image loading skipped because activity will be destroyed for orientation change.");
+            HockeyLog.debug(Constants.TAG, "Image loading skipped because activity will be destroyed for orientation change.");
             return;
         }
 
@@ -187,7 +186,7 @@ public class PaintActivity extends Activity {
                     out.close();
                 } catch (IOException e) {
                     e.printStackTrace();
-                    Log.e(Constants.TAG, "Could not save image.", e);
+                    HockeyLog.error(Constants.TAG, "Could not save image.", e);
                 }
                 return null;
             }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/PaintActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/PaintActivity.java
@@ -20,6 +20,7 @@ import android.view.MenuItem;
 import android.widget.LinearLayout;
 import android.widget.Toast;
 
+import net.hockeyapp.android.utils.HockeyLog;
 import net.hockeyapp.android.views.PaintView;
 
 import java.io.File;
@@ -64,7 +65,7 @@ public class PaintActivity extends Activity {
 
         if (currentOrientation != desiredOrientation) {
       /* Activity will be destroyed again.. skip the following expensive operations. */
-            Log.d(Constants.TAG, "Image loading skipped because activity will be destroyed for orientation change.");
+            HockeyLog.log(Constants.TAG, "Image loading skipped because activity will be destroyed for orientation change.");
             return;
         }
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/tasks/AttachmentDownloader.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/tasks/AttachmentDownloader.java
@@ -5,11 +5,11 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
-import android.util.Log;
 
 import net.hockeyapp.android.Constants;
 import net.hockeyapp.android.objects.FeedbackAttachment;
 import net.hockeyapp.android.utils.AsyncTaskUtils;
+import net.hockeyapp.android.utils.HockeyLog;
 import net.hockeyapp.android.utils.ImageUtils;
 import net.hockeyapp.android.views.AttachmentView;
 
@@ -190,12 +190,12 @@ public class AttachmentDownloader {
             FeedbackAttachment attachment = downloadJob.getFeedbackAttachment();
 
             if (attachment.isAvailableInCache()) {
-                Log.e(Constants.TAG, "Cached...");
+                HockeyLog.error(Constants.TAG, "Cached...");
                 loadImageThumbnail();
                 return true;
 
             } else {
-                Log.e(Constants.TAG, "Downloading...");
+                HockeyLog.error(Constants.TAG, "Downloading...");
                 boolean success = downloadAttachment(attachment.getUrl(), attachment.getCacheId());
                 if (success) {
                     loadImageThumbnail();

--- a/hockeysdk/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTaskWithUI.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTaskWithUI.java
@@ -169,9 +169,9 @@ public class CheckUpdateTaskWithUI extends CheckUpdateTask {
                 DialogFragment updateFragment = (DialogFragment) method.invoke(null, updateInfo, getURLString("apk"));
                 updateFragment.show(fragmentTransaction, "hockey_update_dialog");
             } catch (Exception e) { // can't catch ReflectiveOperationException here because not targeting API level 19 or later
-                Log.d(Constants.TAG, "An exception happened while showing the update fragment:");
+                Log.e(Constants.TAG, "An exception happened while showing the update fragment:");
                 e.printStackTrace();
-                Log.d(Constants.TAG, "Showing update activity instead.");
+                Log.e(Constants.TAG, "Showing update activity instead.");
                 startUpdateIntent(updateInfo, false);
             }
         }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTaskWithUI.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/tasks/CheckUpdateTaskWithUI.java
@@ -9,7 +9,6 @@ import android.app.FragmentTransaction;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Build;
-import android.util.Log;
 import android.widget.Toast;
 
 import net.hockeyapp.android.Constants;
@@ -17,6 +16,7 @@ import net.hockeyapp.android.R;
 import net.hockeyapp.android.UpdateActivity;
 import net.hockeyapp.android.UpdateFragment;
 import net.hockeyapp.android.UpdateManagerListener;
+import net.hockeyapp.android.utils.HockeyLog;
 import net.hockeyapp.android.utils.Util;
 import net.hockeyapp.android.utils.VersionCache;
 
@@ -169,9 +169,9 @@ public class CheckUpdateTaskWithUI extends CheckUpdateTask {
                 DialogFragment updateFragment = (DialogFragment) method.invoke(null, updateInfo, getURLString("apk"));
                 updateFragment.show(fragmentTransaction, "hockey_update_dialog");
             } catch (Exception e) { // can't catch ReflectiveOperationException here because not targeting API level 19 or later
-                Log.e(Constants.TAG, "An exception happened while showing the update fragment:");
+                HockeyLog.error(Constants.TAG, "An exception happened while showing the update fragment:");
                 e.printStackTrace();
-                Log.e(Constants.TAG, "Showing update activity instead.");
+                HockeyLog.error(Constants.TAG, "Showing update activity instead.");
                 startUpdateIntent(updateInfo, false);
             }
         }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/tasks/SendFeedbackTask.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/tasks/SendFeedbackTask.java
@@ -185,7 +185,7 @@ public class SendFeedbackTask extends ConnectionTask<Void, Void, HashMap<String,
                     if (file != null) {
                         Boolean success = file.delete();
                         if (!success) {
-                            HockeyLog.log(TAG, "Error deleting file from temporary folder");
+                            HockeyLog.debug(TAG, "Error deleting file from temporary folder");
                         }
                     }
                 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/tasks/SendFeedbackTask.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/tasks/SendFeedbackTask.java
@@ -8,9 +8,9 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
-import android.util.Log;
 
 import net.hockeyapp.android.Constants;
+import net.hockeyapp.android.utils.HockeyLog;
 import net.hockeyapp.android.utils.HttpURLConnectionBuilder;
 import net.hockeyapp.android.utils.Util;
 
@@ -185,7 +185,7 @@ public class SendFeedbackTask extends ConnectionTask<Void, Void, HashMap<String,
                     if (file != null) {
                         Boolean success = file.delete();
                         if (!success) {
-                            Log.d(TAG, "Error deleting file from temporary folder");
+                            HockeyLog.log(TAG, "Error deleting file from temporary folder");
                         }
                     }
                 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/Base64.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/Base64.java
@@ -728,11 +728,11 @@ public class Base64 {
                 }
 
                 if (tailLen != 0) {
-                    Log.e(TAG, "Error during encoding");
+                    HockeyLog.error(TAG, "Error during encoding");
                     //throw new AssertionError();
                 }
                 if (p != len) {
-                    Log.e(TAG, "Error during encoding");
+                    HockeyLog.error(TAG, "Error during encoding");
                     //throw new AssertionError();
                 }
             } else {

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
@@ -34,50 +34,138 @@ import android.util.Log;
  * @author Benjamin Reimold
  */
 public class HockeyLog {
-    public static final String LOG_IDENTIFIER = "HockeyApp";
+    public static final String HOCKEY_TAG = "HockeyApp";
 
-    private static boolean mDebugLogEnabled = false;
+    public enum LogLevel {
+        VERBOSE(Log.VERBOSE), DEBUG(Log.DEBUG), INFO(Log.INFO), WARN(Log.WARN), ERROR(Log.ERROR), ASSERT(Log.ASSERT);
+        final int systemLogLevel;
+
+        LogLevel(final int systemLogLevel) {
+            this.systemLogLevel = systemLogLevel;
+        }
+
+        public int getStystemLogLevel() {
+            return systemLogLevel;
+        }
+    }
+
+    private static LogLevel sLogLevel = LogLevel.ERROR;
+
 
     /**
-     * Check if debug logging has been enabled.
-     *
-     * @return true/falls to indicate if debug logging has been enabled.
+     * Get the loglevel to find out how much data the HockeySDK spews into LogCat. The Default will be
+     * LOG_LEVEL.ERROR so only errors show up in LogCat.
+     * @return the log level
      */
-    public static boolean isDebugLogEnabled() {
-        return mDebugLogEnabled;
+    public static LogLevel getHockeyLogLevel() {
+        return sLogLevel;
     }
 
     /**
-     * Enable additional output to Log.d(...) by the SDK.
+     * Set the log level to determine the amount of info the HockeySDK spews info into LogCat.
      *
-     * @param debugLogEnabled
+     * @param hockeyLogLevel The log level for hockeySDK logging
      */
-    public static void setDebugLogEnabled(boolean debugLogEnabled) {
-        mDebugLogEnabled = debugLogEnabled;
+    public static void setHockeyLogLevel(LogLevel hockeyLogLevel) {
+        sLogLevel = hockeyLogLevel;
     }
 
-    /**
-     * Log a message to Log.d(TAG, message) if debug logging has been enabled.
-     *
-     * @param message the message to log to Log.d, if it is null, nothing will be logged.
-     */
-    public static void log(String message) {
-        log(null, message);
+    public static void verbose(String message) {
+        verbose(null, message);
     }
 
-    /**
-     * Log a message to Log.d(TAG, message) if debug logging has been enabled.
-     *
-     * @param tag,    the tag used for logging. If null, it will default to HockeyApp
-     * @param message the message to log to Log.d, if it is null, nothing will be logged.
-     */
-    public static void log(String tag, String message) {
-        if (isDebugLogEnabled() && (message != null)) {
-            if (tag == null) {
-                tag = LOG_IDENTIFIER;
-            }
+    public static void verbose(String tag, String message) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.VERBOSE) {
+            Log.v(tag, message);
+        }
+    }
 
+    public static void verbose(String tag, String message, Throwable throwable) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.VERBOSE) {
+            Log.v(tag, message, throwable);
+        }
+    }
+
+    public static void debug(String message) {
+        debug(null, message);
+    }
+
+    public static void debug(String tag, String message) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.DEBUG) {
             Log.d(tag, message);
         }
     }
+
+    public static void debug(String tag, String message, Throwable throwable) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.DEBUG) {
+            Log.d(tag, message, throwable);
+        }
+    }
+
+    public static void info(String message) {
+        info(null, message);
+    }
+
+    public static void info(String tag, String message) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.INFO) {
+            Log.i(tag, message);
+        }
+    }
+
+    public static void info(String tag, String message, Throwable throwable) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.INFO) {
+            Log.i(tag, message, throwable);
+        }
+    }
+
+    public static void warn(String message) {
+        warn(null, message);
+    }
+
+    public static void warn(String tag, String message) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.WARN) {
+            Log.w(tag, message);
+        }
+    }
+
+    public static void warn(String tag, String message, Throwable throwable) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.WARN) {
+            Log.w(tag, message, throwable);
+        }
+    }
+
+    public static void error(String message) {
+        error(null, message);
+    }
+
+    public static void error(String tag, String message) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.ERROR) {
+            Log.e(tag, message);
+        }
+    }
+
+    public static void error(String tag, String message, Throwable throwable) {
+        tag = sanitizeTag(tag);
+        if (sLogLevel.systemLogLevel <= Log.ERROR) {
+            Log.e(tag, message, throwable);
+        }
+    }
+
+    private static String sanitizeTag(String tag) {
+        if((tag == null) || (tag.length() == 0) || (tag.length() > 23) ) {
+            tag = HOCKEY_TAG;
+        }
+
+        return tag;
+    }
+
 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
@@ -37,7 +37,7 @@ public class HockeyLog {
     public static final String HOCKEY_TAG = "HockeyApp";
 
     public enum LogLevel {
-        VERBOSE(Log.VERBOSE), DEBUG(Log.DEBUG), INFO(Log.INFO), WARN(Log.WARN), ERROR(Log.ERROR), ASSERT(Log.ASSERT);
+        VERBOSE(Log.VERBOSE), DEBUG(Log.DEBUG), INFO(Log.INFO), WARN(Log.WARN), ERROR(Log.ERROR);
         final int systemLogLevel;
 
         LogLevel(final int systemLogLevel) {
@@ -70,10 +70,21 @@ public class HockeyLog {
         sLogLevel = hockeyLogLevel;
     }
 
+    /**
+     * Log a message with level VERBOSE
+     *
+     * @param message the log message
+     */
     public static void verbose(String message) {
         verbose(null, message);
     }
 
+    /**
+     * Log a message with level VERBOSE
+     *
+     * @param tag the TAG
+     * @param message the log message
+     */
     public static void verbose(String tag, String message) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.VERBOSE) {
@@ -81,6 +92,13 @@ public class HockeyLog {
         }
     }
 
+    /**
+     * Log a message with level VERBOSE
+     *
+     * @param tag the TAG
+     * @param message the log message
+     * @param throwable the throwable you want to log
+     */
     public static void verbose(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.VERBOSE) {
@@ -88,10 +106,21 @@ public class HockeyLog {
         }
     }
 
+    /**
+     * Log a message with level DEBUG
+     *
+     * @param message the log message
+     */
     public static void debug(String message) {
         debug(null, message);
     }
 
+    /**
+     * Log a message with level DEBUG
+     *
+     * @param tag the TAG
+     * @param message the log message
+     */
     public static void debug(String tag, String message) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.DEBUG) {
@@ -99,6 +128,13 @@ public class HockeyLog {
         }
     }
 
+    /**
+     * Log a message with level DEBUG
+     *
+     * @param tag the TAG
+     * @param message the log message
+     * @param throwable the throwable you want to log
+     */
     public static void debug(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.DEBUG) {
@@ -106,10 +142,21 @@ public class HockeyLog {
         }
     }
 
+    /**
+     * Log a message with level INFO
+     *
+     * @param message the log message
+     */
     public static void info(String message) {
         info(null, message);
     }
 
+    /**
+     * Log a message with level INFO
+     *
+     * @param tag the TAG
+     * @param message the log message
+     */
     public static void info(String tag, String message) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.INFO) {
@@ -117,6 +164,13 @@ public class HockeyLog {
         }
     }
 
+    /**
+     * Log a message with level INFO
+     *
+     * @param tag the TAG
+     * @param message the log message
+     * @param throwable the throwable you want to log
+     */
     public static void info(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.INFO) {
@@ -124,10 +178,21 @@ public class HockeyLog {
         }
     }
 
+    /**
+     * Log a message with level WARN
+     *
+     * @param message the log message
+     */
     public static void warn(String message) {
         warn(null, message);
     }
 
+    /**
+     * Log a message with level WARN
+     *
+     * @param tag the TAG
+     * @param message the log message
+     */
     public static void warn(String tag, String message) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.WARN) {
@@ -135,6 +200,13 @@ public class HockeyLog {
         }
     }
 
+    /**
+     * Log a message with level WARN
+     *
+     * @param tag the TAG
+     * @param message the log message
+     * @param throwable the throwable you want to log
+     */
     public static void warn(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.WARN) {
@@ -142,10 +214,21 @@ public class HockeyLog {
         }
     }
 
+    /**
+     * Log a message with level ERROR
+     *
+     * @param message the log message
+     */
     public static void error(String message) {
         error(null, message);
     }
 
+    /**
+     * Log a message with level ERROR
+     *
+     * @param tag the TAG
+     * @param message the log message
+     */
     public static void error(String tag, String message) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.ERROR) {
@@ -153,6 +236,13 @@ public class HockeyLog {
         }
     }
 
+    /**
+     * Log a message with level ERROR
+     *
+     * @param tag the TAG
+     * @param message the log message
+     * @param throwable the throwable you want to log
+     */
     public static void error(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
         if (sLogLevel.systemLogLevel <= Log.ERROR) {
@@ -160,7 +250,13 @@ public class HockeyLog {
         }
     }
 
-    private static String sanitizeTag(String tag) {
+    /**
+     * Sanitize a TAG string
+     * @param tag the tag for the logging
+     * @return a sanitized TAG, defaults to 'HockeyApp' in case the tag is null, empty or longer than
+     * 23 characters.
+     */
+    static String sanitizeTag(String tag) {
         if((tag == null) || (tag.length() == 0) || (tag.length() > 23) ) {
             tag = HOCKEY_TAG;
         }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
@@ -36,28 +36,14 @@ import android.util.Log;
 public class HockeyLog {
     public static final String HOCKEY_TAG = "HockeyApp";
 
-    public enum LogLevel {
-        VERBOSE(Log.VERBOSE), DEBUG(Log.DEBUG), INFO(Log.INFO), WARN(Log.WARN), ERROR(Log.ERROR);
-        final int systemLogLevel;
-
-        LogLevel(final int systemLogLevel) {
-            this.systemLogLevel = systemLogLevel;
-        }
-
-        public int getStystemLogLevel() {
-            return systemLogLevel;
-        }
-    }
-
-    private static LogLevel sLogLevel = LogLevel.ERROR;
-
+    private static int sLogLevel = Log.ERROR;
 
     /**
      * Get the loglevel to find out how much data the HockeySDK spews into LogCat. The Default will be
      * LOG_LEVEL.ERROR so only errors show up in LogCat.
      * @return the log level
      */
-    public static LogLevel getHockeyLogLevel() {
+    public static int getLogLevel() {
         return sLogLevel;
     }
 
@@ -66,7 +52,7 @@ public class HockeyLog {
      *
      * @param hockeyLogLevel The log level for hockeySDK logging
      */
-    public static void setHockeyLogLevel(LogLevel hockeyLogLevel) {
+    public static void setLogLevel(int hockeyLogLevel) {
         sLogLevel = hockeyLogLevel;
     }
 
@@ -87,7 +73,7 @@ public class HockeyLog {
      */
     public static void verbose(String tag, String message) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.VERBOSE) {
+        if (sLogLevel <= Log.VERBOSE) {
             Log.v(tag, message);
         }
     }
@@ -101,7 +87,7 @@ public class HockeyLog {
      */
     public static void verbose(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.VERBOSE) {
+        if (sLogLevel <= Log.VERBOSE) {
             Log.v(tag, message, throwable);
         }
     }
@@ -123,7 +109,7 @@ public class HockeyLog {
      */
     public static void debug(String tag, String message) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.DEBUG) {
+        if (sLogLevel <= Log.DEBUG) {
             Log.d(tag, message);
         }
     }
@@ -137,7 +123,7 @@ public class HockeyLog {
      */
     public static void debug(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.DEBUG) {
+        if (sLogLevel <= Log.DEBUG) {
             Log.d(tag, message, throwable);
         }
     }
@@ -159,7 +145,7 @@ public class HockeyLog {
      */
     public static void info(String tag, String message) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.INFO) {
+        if (sLogLevel <= Log.INFO) {
             Log.i(tag, message);
         }
     }
@@ -173,7 +159,7 @@ public class HockeyLog {
      */
     public static void info(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.INFO) {
+        if (sLogLevel <= Log.INFO) {
             Log.i(tag, message, throwable);
         }
     }
@@ -195,7 +181,7 @@ public class HockeyLog {
      */
     public static void warn(String tag, String message) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.WARN) {
+        if (sLogLevel <= Log.WARN) {
             Log.w(tag, message);
         }
     }
@@ -209,7 +195,7 @@ public class HockeyLog {
      */
     public static void warn(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.WARN) {
+        if (sLogLevel <= Log.WARN) {
             Log.w(tag, message, throwable);
         }
     }
@@ -231,7 +217,7 @@ public class HockeyLog {
      */
     public static void error(String tag, String message) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.ERROR) {
+        if (sLogLevel <= Log.ERROR) {
             Log.e(tag, message);
         }
     }
@@ -245,7 +231,7 @@ public class HockeyLog {
      */
     public static void error(String tag, String message, Throwable throwable) {
         tag = sanitizeTag(tag);
-        if (sLogLevel.systemLogLevel <= Log.ERROR) {
+        if (sLogLevel <= Log.ERROR) {
             Log.e(tag, message, throwable);
         }
     }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
@@ -1,0 +1,83 @@
+package net.hockeyapp.android.utils;
+
+
+import android.util.Log;
+
+/**
+ * <h3>License</h3>
+ * <p/>
+ * <pre>
+ * Copyright (c) 2011-2015 Bit Stadium GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * </pre>
+ *
+ * @author Benjamin Reimold
+ */
+public class HockeyLog {
+    public static final String LOG_IDENTIFIER = "HockeyApp";
+
+    private static boolean mDebugLogEnabled = false;
+
+    /**
+     * Check if debug logging has been enabled.
+     *
+     * @return true/falls to indicate if debug logging has been enabled.
+     */
+    public static boolean isDebugLogEnabled() {
+        return mDebugLogEnabled;
+    }
+
+    /**
+     * Enable additional output to Log.d(...) by the SDK.
+     *
+     * @param debugLogEnabled
+     */
+    public static void setDebugLogEnabled(boolean debugLogEnabled) {
+        mDebugLogEnabled = debugLogEnabled;
+    }
+
+    /**
+     * Log a message to Log.d(TAG, message) if debug logging has been enabled.
+     *
+     * @param message the message to log to Log.d, if it is null, nothing will be logged.
+     */
+    public static void log(String message) {
+        log(null, message);
+    }
+
+    /**
+     * Log a message to Log.d(TAG, message) if debug logging has been enabled.
+     *
+     * @param tag,    the tag used for logging. If null, it will default to HockeyApp
+     * @param message the message to log to Log.d, if it is null, nothing will be logged.
+     */
+    public static void log(String tag, String message) {
+        if (isDebugLogEnabled() && (message != null)) {
+            if (tag == null) {
+                tag = LOG_IDENTIFIER;
+            }
+
+            Log.d(tag, message);
+        }
+    }
+}

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/HockeyLog.java
@@ -41,6 +41,7 @@ public class HockeyLog {
     /**
      * Get the loglevel to find out how much data the HockeySDK spews into LogCat. The Default will be
      * LOG_LEVEL.ERROR so only errors show up in LogCat.
+     *
      * @return the log level
      */
     public static int getLogLevel() {
@@ -59,16 +60,7 @@ public class HockeyLog {
     /**
      * Log a message with level VERBOSE
      *
-     * @param message the log message
-     */
-    public static void verbose(String message) {
-        verbose(null, message);
-    }
-
-    /**
-     * Log a message with level VERBOSE
-     *
-     * @param tag the TAG
+     * @param tag     the TAG
      * @param message the log message
      */
     public static void verbose(String tag, String message) {
@@ -81,8 +73,8 @@ public class HockeyLog {
     /**
      * Log a message with level VERBOSE
      *
-     * @param tag the TAG
-     * @param message the log message
+     * @param tag       the TAG
+     * @param message   the log message
      * @param throwable the throwable you want to log
      */
     public static void verbose(String tag, String message, Throwable throwable) {
@@ -104,7 +96,7 @@ public class HockeyLog {
     /**
      * Log a message with level DEBUG
      *
-     * @param tag the TAG
+     * @param tag     the TAG
      * @param message the log message
      */
     public static void debug(String tag, String message) {
@@ -117,8 +109,8 @@ public class HockeyLog {
     /**
      * Log a message with level DEBUG
      *
-     * @param tag the TAG
-     * @param message the log message
+     * @param tag       the TAG
+     * @param message   the log message
      * @param throwable the throwable you want to log
      */
     public static void debug(String tag, String message, Throwable throwable) {
@@ -140,7 +132,7 @@ public class HockeyLog {
     /**
      * Log a message with level INFO
      *
-     * @param tag the TAG
+     * @param tag     the TAG
      * @param message the log message
      */
     public static void info(String tag, String message) {
@@ -153,8 +145,8 @@ public class HockeyLog {
     /**
      * Log a message with level INFO
      *
-     * @param tag the TAG
-     * @param message the log message
+     * @param tag       the TAG
+     * @param message   the log message
      * @param throwable the throwable you want to log
      */
     public static void info(String tag, String message, Throwable throwable) {
@@ -176,7 +168,7 @@ public class HockeyLog {
     /**
      * Log a message with level WARN
      *
-     * @param tag the TAG
+     * @param tag     the TAG
      * @param message the log message
      */
     public static void warn(String tag, String message) {
@@ -189,8 +181,8 @@ public class HockeyLog {
     /**
      * Log a message with level WARN
      *
-     * @param tag the TAG
-     * @param message the log message
+     * @param tag       the TAG
+     * @param message   the log message
      * @param throwable the throwable you want to log
      */
     public static void warn(String tag, String message, Throwable throwable) {
@@ -212,7 +204,7 @@ public class HockeyLog {
     /**
      * Log a message with level ERROR
      *
-     * @param tag the TAG
+     * @param tag     the TAG
      * @param message the log message
      */
     public static void error(String tag, String message) {
@@ -225,8 +217,8 @@ public class HockeyLog {
     /**
      * Log a message with level ERROR
      *
-     * @param tag the TAG
-     * @param message the log message
+     * @param tag       the TAG
+     * @param message   the log message
      * @param throwable the throwable you want to log
      */
     public static void error(String tag, String message, Throwable throwable) {
@@ -238,12 +230,13 @@ public class HockeyLog {
 
     /**
      * Sanitize a TAG string
+     *
      * @param tag the tag for the logging
      * @return a sanitized TAG, defaults to 'HockeyApp' in case the tag is null, empty or longer than
      * 23 characters.
      */
     static String sanitizeTag(String tag) {
-        if((tag == null) || (tag.length() == 0) || (tag.length() > 23) ) {
+        if ((tag == null) || (tag.length() == 0) || (tag.length() > 23)) {
             tag = HOCKEY_TAG;
         }
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/views/AttachmentListView.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/views/AttachmentListView.java
@@ -3,9 +3,10 @@ package net.hockeyapp.android.views;
 import android.content.Context;
 import android.net.Uri;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
+
+import net.hockeyapp.android.utils.HockeyLog;
 
 import java.util.ArrayList;
 
@@ -75,7 +76,7 @@ public class AttachmentListView extends ViewGroup {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         if ((MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.UNSPECIFIED)) {
-            Log.d(TAG, "Width is unspecified");
+            HockeyLog.log(TAG, "Width is unspecified");
             //throw new AssertionError();
         }
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/views/AttachmentListView.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/views/AttachmentListView.java
@@ -76,7 +76,7 @@ public class AttachmentListView extends ViewGroup {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         if ((MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.UNSPECIFIED)) {
-            HockeyLog.log(TAG, "Width is unspecified");
+            HockeyLog.debug(TAG, "Width is unspecified");
             //throw new AssertionError();
         }
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/views/PaintView.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/views/PaintView.java
@@ -10,11 +10,11 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.widget.ImageView;
 
 import net.hockeyapp.android.Constants;
+import net.hockeyapp.android.utils.HockeyLog;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -79,7 +79,7 @@ public class PaintView extends ImageView {
             return ratio > 1 ? ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE : ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
 
         } catch (IOException e) {
-            Log.e(Constants.TAG, "Unable to determine necessary screen orientation.", e);
+            HockeyLog.error(Constants.TAG, "Unable to determine necessary screen orientation.", e);
             return ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
         }
     }
@@ -184,7 +184,7 @@ public class PaintView extends ImageView {
                     Bitmap bm = decodeSampledBitmapFromResource(context.getContentResolver(), imageUri, displayWidth, displayHeight);
                     return bm;
                 } catch (IOException e) {
-                    Log.e(Constants.TAG, "Could not load image into ImageView.", e);
+                    HockeyLog.error(Constants.TAG, "Could not load image into ImageView.", e);
                 }
                 return null;
             }

--- a/hockeysdk/src/test/java/net/hockeyapp/android/utils/HockeyLogTest.java
+++ b/hockeysdk/src/test/java/net/hockeyapp/android/utils/HockeyLogTest.java
@@ -40,11 +40,4 @@ public class HockeyLogTest {
         expected = "Awesome Hockey SDK";
         Assert.assertEquals(expected, actual);
     }
-
-    @Test
-    public void logLevelsWork() {
-        HockeyLog.debug("Something happened");
-        Log mockLog ()
-    }
-
 }

--- a/hockeysdk/src/test/java/net/hockeyapp/android/utils/HockeyLogTest.java
+++ b/hockeysdk/src/test/java/net/hockeyapp/android/utils/HockeyLogTest.java
@@ -1,0 +1,50 @@
+package net.hockeyapp.android.utils;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+public class HockeyLogTest {
+
+    @Test
+    public void setLogLevelWorks() {
+        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.DEBUG);
+        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.DEBUG);
+        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.INFO);
+        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.INFO);
+        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.ERROR);
+        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.ERROR);
+        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.WARN);
+        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.WARN);
+        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.VERBOSE);
+        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.VERBOSE);
+    }
+
+    @Test
+    public void sanitizeTagWorks() {
+        String actual = HockeyLog.sanitizeTag(null);
+        String expected = "HockeyApp";
+        Assert.assertEquals(expected, actual);
+
+        actual = HockeyLog.sanitizeTag("");
+        Assert.assertEquals(expected, actual);
+
+        actual = HockeyLog.sanitizeTag("SomethingLongerThanTwentyThreeChars");
+        Assert.assertEquals(expected, actual);
+
+        expected = "Exactly2ThreeCharacters";
+        actual = HockeyLog.sanitizeTag("Exactly2ThreeCharacters");
+        Assert.assertEquals(expected, actual);
+
+        actual = "Awesome Hockey SDK";
+        expected = "Awesome Hockey SDK";
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void logLevelsWork() {
+        HockeyLog.debug("Something happened");
+        Log mockLog ()
+    }
+
+}

--- a/hockeysdk/src/test/java/net/hockeyapp/android/utils/HockeyLogTest.java
+++ b/hockeysdk/src/test/java/net/hockeyapp/android/utils/HockeyLogTest.java
@@ -1,5 +1,7 @@
 package net.hockeyapp.android.utils;
 
+import android.util.Log;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
@@ -8,16 +10,16 @@ public class HockeyLogTest {
 
     @Test
     public void setLogLevelWorks() {
-        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.DEBUG);
-        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.DEBUG);
-        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.INFO);
-        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.INFO);
-        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.ERROR);
-        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.ERROR);
-        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.WARN);
-        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.WARN);
-        HockeyLog.setHockeyLogLevel(HockeyLog.LogLevel.VERBOSE);
-        Assert.assertTrue(HockeyLog.getHockeyLogLevel() == HockeyLog.LogLevel.VERBOSE);
+        HockeyLog.setLogLevel(Log.DEBUG);
+        Assert.assertTrue(HockeyLog.getLogLevel() == Log.DEBUG);
+        HockeyLog.setLogLevel(Log.INFO);
+        Assert.assertTrue(HockeyLog.getLogLevel() == Log.INFO);
+        HockeyLog.setLogLevel(Log.ERROR);
+        Assert.assertTrue(HockeyLog.getLogLevel() == Log.ERROR);
+        HockeyLog.setLogLevel(Log.WARN);
+        Assert.assertTrue(HockeyLog.getLogLevel() == Log.WARN);
+        HockeyLog.setLogLevel(Log.VERBOSE);
+        Assert.assertTrue(HockeyLog.getLogLevel() == Log.VERBOSE);
     }
 
     @Test

--- a/hockeysdk/src/test/java/net/hockeyapp/android/utils/HockeyLogTest.java
+++ b/hockeysdk/src/test/java/net/hockeyapp/android/utils/HockeyLogTest.java
@@ -24,8 +24,8 @@ public class HockeyLogTest {
 
     @Test
     public void sanitizeTagWorks() {
+        String expected = HockeyLog.HOCKEY_TAG;
         String actual = HockeyLog.sanitizeTag(null);
-        String expected = "HockeyApp";
         Assert.assertEquals(expected, actual);
 
         actual = HockeyLog.sanitizeTag("");
@@ -38,8 +38,8 @@ public class HockeyLogTest {
         actual = HockeyLog.sanitizeTag("Exactly2ThreeCharacters");
         Assert.assertEquals(expected, actual);
 
-        actual = "Awesome Hockey SDK";
         expected = "Awesome Hockey SDK";
+        actual = HockeyLog.sanitizeTag("Awesome Hockey SDK");
         Assert.assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
@ranterle 
* We've used Log.d for all of the log messages. I mostly replaced them with the new HockeyLog.log(..)
* I have left Log.e-calls in place but they might also fall under the new logging logic. Feel free to leave comments on this, or proceed changing this. I, personally think critical errors should appear in the devs logcat all the time. 
* I put the logging wrapper in our Util-class but then decided to put it in a sep. class. If you like it better as part of Util, feel free to change or tell me to do so. =)