### PR TITLE
Throw IOException to prevent crash in LoginTask

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/HttpURLConnectionBuilder.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/HttpURLConnectionBuilder.java
@@ -143,49 +143,45 @@ public class HttpURLConnectionBuilder {
         return this;
     }
 
-    public HttpURLConnection build() {
+    public HttpURLConnection build() throws IOException {
         HttpURLConnection connection;
-        try {
-            URL url = new URL(mUrlString);
-            connection = (HttpURLConnection) url.openConnection();
+        URL url = new URL(mUrlString);
+        connection = (HttpURLConnection) url.openConnection();
 
-            connection.setConnectTimeout(mTimeout);
-            connection.setReadTimeout(mTimeout);
+        connection.setConnectTimeout(mTimeout);
+        connection.setReadTimeout(mTimeout);
 
-            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD) {
-                connection.setRequestProperty("Connection", "close");
-            }
-
-            if (!TextUtils.isEmpty(mRequestMethod)) {
-                connection.setRequestMethod(mRequestMethod);
-                if (!TextUtils.isEmpty(mRequestBody) || mRequestMethod.equalsIgnoreCase("POST") || mRequestMethod.equalsIgnoreCase("PUT")) {
-                    connection.setDoOutput(true);
-                }
-            }
-
-            for (String name : mHeaders.keySet()) {
-                connection.setRequestProperty(name, mHeaders.get(name));
-            }
-
-            if (!TextUtils.isEmpty(mRequestBody)) {
-                OutputStream outputStream = connection.getOutputStream();
-                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, DEFAULT_CHARSET));
-                writer.write(mRequestBody);
-                writer.flush();
-                writer.close();
-            }
-
-            if (mMultipartEntity != null) {
-                connection.setRequestProperty("Content-Length", String.valueOf(mMultipartEntity.getContentLength()));
-                BufferedOutputStream outputStream = new BufferedOutputStream(connection.getOutputStream());
-                outputStream.write(mMultipartEntity.getOutputStream().toByteArray());
-                outputStream.flush();
-                outputStream.close();
-            }
-
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD) {
+            connection.setRequestProperty("Connection", "close");
         }
+
+        if (!TextUtils.isEmpty(mRequestMethod)) {
+            connection.setRequestMethod(mRequestMethod);
+            if (!TextUtils.isEmpty(mRequestBody) || mRequestMethod.equalsIgnoreCase("POST") || mRequestMethod.equalsIgnoreCase("PUT")) {
+                connection.setDoOutput(true);
+            }
+        }
+
+        for (String name : mHeaders.keySet()) {
+            connection.setRequestProperty(name, mHeaders.get(name));
+        }
+
+        if (!TextUtils.isEmpty(mRequestBody)) {
+            OutputStream outputStream = connection.getOutputStream();
+            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream, DEFAULT_CHARSET));
+            writer.write(mRequestBody);
+            writer.flush();
+            writer.close();
+        }
+
+        if (mMultipartEntity != null) {
+            connection.setRequestProperty("Content-Length", String.valueOf(mMultipartEntity.getContentLength()));
+            BufferedOutputStream outputStream = new BufferedOutputStream(connection.getOutputStream());
+            outputStream.write(mMultipartEntity.getOutputStream().toByteArray());
+            outputStream.flush();
+            outputStream.close();
+        }
+
         return connection;
     }
 


### PR DESCRIPTION
Crash was caused in LoginTask when signing in with mode "email_only" when connected to wifi but no internet connectivity - the exact details of why this is then throwing an IOException but the same login with mode "email_password" does not will stay with the implementors of URLConnection.
The code is now just throwing the IOException to the next in the chain so they can handle it correctly.