### PR TITLE
Add last crash details feature

### DIFF
--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerTest.java
@@ -4,14 +4,21 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.InstrumentationTestCase;
 
+import net.hockeyapp.android.objects.CrashDetails;
+import net.hockeyapp.android.util.StacktraceFilenameFilter;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.File;
+
 @RunWith(AndroidJUnit4.class)
 public class CrashManagerTest extends InstrumentationTestCase {
 
-    public static final String DUMMY_APP_IDENTIFIER = "12345678901234567890123456789012";
+    private static final String DUMMY_APP_IDENTIFIER = "12345678901234567890123456789012";
+
+    private static final StacktraceFilenameFilter STACK_TRACE_FILTER = new StacktraceFilenameFilter();
 
     @Before
     public void setUp() throws Exception {
@@ -35,13 +42,74 @@ public class CrashManagerTest extends InstrumentationTestCase {
 
     @Test
     public void crashInLastSessionRecognized() {
-        Throwable tr = new RuntimeException("Just a test exception");
-        ExceptionHandler.saveException(tr, Thread.currentThread(), null);
+        fakeCrashReport();
         assertNotNull(Constants.FILES_PATH);
 
         CrashManager.register(getInstrumentation().getTargetContext(), DUMMY_APP_IDENTIFIER);
 
         assertTrue(CrashManager.didCrashInLastSession());
+        assertNotNull(CrashManager.getLastCrashDetails());
+    }
+
+    @Test
+    public void crashDetailsInLastSessionCorrect() {
+        assertNotNull(Constants.FILES_PATH);
+
+        cleanupReportsDir();
+        fakeCrashReport();
+
+        CrashManager.register(getInstrumentation().getTargetContext(), DUMMY_APP_IDENTIFIER);
+
+        CrashDetails crashDetails = CrashManager.getLastCrashDetails();
+
+        assertNotNull(crashDetails);
+
+        File lastStackTrace = lastCrashReportFile();
+        assertNotNull(lastStackTrace);
+
+        assertEquals(lastStackTrace.getName().substring(0, lastStackTrace.getName().indexOf(".stacktrace")), crashDetails.getCrashIdentifier());
+        assertEquals(Constants.CRASH_IDENTIFIER, crashDetails.getReporterKey());
+
+        fakeCrashReport();
+        fakeCrashReport();
+        fakeCrashReport();
+
+        crashDetails = CrashManager.getLastCrashDetails();
+
+        assertNotNull(crashDetails);
+
+        lastStackTrace = lastCrashReportFile();
+        assertNotNull(lastStackTrace);
+
+        assertEquals(lastStackTrace.getName().substring(0, lastStackTrace.getName().indexOf(".stacktrace")), crashDetails.getCrashIdentifier());
+    }
+
+    private static void cleanupReportsDir() {
+        assertNotNull(Constants.FILES_PATH);
+        File reportsDir = new File(Constants.FILES_PATH);
+        for (File f : reportsDir.listFiles(STACK_TRACE_FILTER)) {
+            f.delete();
+        }
+    }
+
+    private static void fakeCrashReport() {
+        Throwable tr = new RuntimeException("Just a test exception");
+        ExceptionHandler.saveException(tr, Thread.currentThread(), null);
+    }
+
+    private static File lastCrashReportFile() {
+        assertNotNull(Constants.FILES_PATH);
+        File reportsDir = new File(Constants.FILES_PATH);
+
+        long modifiedReference = 0;
+        File lastReportsFile = null;
+        for (File f : reportsDir.listFiles(STACK_TRACE_FILTER)) {
+            if (f.lastModified() > modifiedReference) {
+                modifiedReference = f.lastModified();
+                lastReportsFile = f;
+            }
+        }
+        return lastReportsFile;
     }
 
 

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerTest.java
@@ -1,0 +1,48 @@
+package net.hockeyapp.android;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.InstrumentationTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class CrashManagerTest extends InstrumentationTestCase {
+
+    public static final String DUMMY_APP_IDENTIFIER = "12345678901234567890123456789012";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        injectInstrumentation(InstrumentationRegistry.getInstrumentation());
+
+        if (Constants.FILES_PATH == null) {
+            Constants.loadFromContext(getInstrumentation().getTargetContext());
+        }
+    }
+
+    @Test
+    public void registerCrashManagerWorks() {
+        // verify that registering the Crash Manager works (e.g. it's not throwing any exception)
+        CrashManager.register(getInstrumentation().getTargetContext(), DUMMY_APP_IDENTIFIER);
+
+        // verify that there were no crashes in the last session
+        assertFalse(CrashManager.didCrashInLastSession());
+    }
+
+    @Test
+    public void crashInLastSessionRecognized() {
+        Throwable tr = new RuntimeException("Just a test exception");
+        ExceptionHandler.saveException(tr, Thread.currentThread(), null);
+        assertNotNull(Constants.FILES_PATH);
+
+        CrashManager.register(getInstrumentation().getTargetContext(), DUMMY_APP_IDENTIFIER);
+
+        assertTrue(CrashManager.didCrashInLastSession());
+    }
+
+
+}

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/ExceptionHandlerTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/ExceptionHandlerTest.java
@@ -4,12 +4,13 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.InstrumentationTestCase;
 
+import net.hockeyapp.android.util.StacktraceFilenameFilter;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.io.FilenameFilter;
 
 @RunWith(AndroidJUnit4.class)
 public class ExceptionHandlerTest extends InstrumentationTestCase {
@@ -37,12 +38,16 @@ public class ExceptionHandlerTest extends InstrumentationTestCase {
     @Test
     public void saveExceptionTest() {
 
-        Throwable tr = new RuntimeException("Just a test exception");
-
-        ExceptionHandler.saveException(tr, null, null);
+        fakeCrashReport();
 
         File[] files = filesDirectory.listFiles(new StacktraceFilenameFilter());
         assertEquals(1, files.length);
+
+        fakeCrashReport();
+        fakeCrashReport();
+
+        files = filesDirectory.listFiles(new StacktraceFilenameFilter());
+        assertEquals(3, files.length);
     }
 
     @SuppressWarnings("ThrowableInstanceNeverThrown")
@@ -58,12 +63,9 @@ public class ExceptionHandlerTest extends InstrumentationTestCase {
         assertEquals(1, files.length);
     }
 
-    static class StacktraceFilenameFilter implements FilenameFilter {
-
-        @Override
-        public boolean accept(File dir, String filename) {
-            return filename.endsWith(".stacktrace");
-        }
+    private static void fakeCrashReport() {
+        Throwable tr = new RuntimeException("Just a test exception");
+        ExceptionHandler.saveException(tr, Thread.currentThread(), null);
     }
 
 }

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/ExceptionHandlerTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/ExceptionHandlerTest.java
@@ -2,7 +2,7 @@ package net.hockeyapp.android;
 
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.ActivityInstrumentationTestCase2;
+import android.test.InstrumentationTestCase;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -12,13 +12,9 @@ import java.io.File;
 import java.io.FilenameFilter;
 
 @RunWith(AndroidJUnit4.class)
-public class ExceptionHandlerTest extends ActivityInstrumentationTestCase2<UpdateActivity> {
+public class ExceptionHandlerTest extends InstrumentationTestCase {
 
     private File filesDirectory;
-
-    public ExceptionHandlerTest() {
-        super(UpdateActivity.class);
-    }
 
     @Before
     public void setUp() throws Exception {
@@ -27,7 +23,7 @@ public class ExceptionHandlerTest extends ActivityInstrumentationTestCase2<Updat
         injectInstrumentation(InstrumentationRegistry.getInstrumentation());
 
         if (Constants.FILES_PATH == null) {
-            Constants.loadFromContext(getActivity());
+            Constants.loadFromContext(getInstrumentation().getTargetContext());
         }
 
         filesDirectory = new File(Constants.FILES_PATH);

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/objects/CrashDetailsTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/objects/CrashDetailsTest.java
@@ -1,0 +1,86 @@
+package net.hockeyapp.android.objects;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.InstrumentationTestCase;
+import android.text.TextUtils;
+
+import net.hockeyapp.android.Constants;
+import net.hockeyapp.android.ExceptionHandler;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+
+@RunWith(AndroidJUnit4.class)
+public class CrashDetailsTest extends InstrumentationTestCase {
+
+    private File filesDirectory;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        injectInstrumentation(InstrumentationRegistry.getInstrumentation());
+
+        if (Constants.FILES_PATH == null) {
+            Constants.loadFromContext(getInstrumentation().getTargetContext());
+        }
+
+        // Create some fake data
+        Constants.APP_VERSION = "1";
+        Constants.APP_VERSION_NAME = "1.0";
+
+        filesDirectory = new File(Constants.FILES_PATH);
+        File[] stacktraceFiles = filesDirectory.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String filename) {
+                return filename.endsWith(".stacktrace");
+            }
+        });
+        for (File f : stacktraceFiles) {
+            f.delete();
+        }
+    }
+
+    @Test
+    public void testCrashDetailParsing() throws IOException {
+        Throwable tr = new RuntimeException("Just a test exception");
+        ExceptionHandler.saveException(tr, Thread.currentThread(), null);
+
+        File[] stackTraceFiles = filesDirectory.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String filename) {
+                return filename.endsWith(".stacktrace");
+            }
+        });
+
+        assertEquals(1, stackTraceFiles.length);
+
+        File stackTraceFile = stackTraceFiles[0];
+        String crashIdentifier = stackTraceFile.getName().substring(0, stackTraceFile.getName().indexOf(".stacktrace"));
+
+        CrashDetails details = CrashDetails.fromFile(stackTraceFile);
+        assertNotNull(details);
+
+        assertFalse(TextUtils.isEmpty(details.getCrashIdentifier()));
+
+        assertEquals(crashIdentifier, details.getCrashIdentifier());
+        assertEquals(Constants.CRASH_IDENTIFIER, details.getReporterKey());
+        assertEquals(Constants.ANDROID_VERSION, details.getOsVersion());
+        assertEquals(Constants.ANDROID_BUILD, details.getOsBuild());
+        assertEquals(Constants.PHONE_MANUFACTURER, details.getDeviceManufacturer());
+        assertEquals(Constants.PHONE_MODEL, details.getDeviceModel());
+        assertEquals(Constants.APP_VERSION_NAME, details.getAppVersionName());
+        assertEquals(Constants.APP_VERSION, details.getAppVersionCode());
+        assertEquals(Thread.currentThread().getName() + "-" + Thread.currentThread().getId(), details.getThreadName());
+
+        assertNotNull(details.getAppStartDate());
+        assertNotNull(details.getAppCrashDate());
+        assertTrue("Crash date must be later than initialization date", details.getAppCrashDate().compareTo(details.getAppStartDate()) > 0);
+    }
+}

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/util/StacktraceFilenameFilter.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/util/StacktraceFilenameFilter.java
@@ -1,0 +1,12 @@
+package net.hockeyapp.android.util;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+public class StacktraceFilenameFilter implements FilenameFilter {
+
+    @Override
+    public boolean accept(File dir, String filename) {
+        return filename.endsWith(".stacktrace");
+    }
+}

--- a/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
@@ -96,6 +96,11 @@ public class Constants {
      */
     public static String ANDROID_VERSION = null;
     /**
+     * The device's OS build.
+     */
+    public static String ANDROID_BUILD = null;
+
+    /**
      * The device's model name.
      */
     public static String PHONE_MODEL = null;
@@ -116,6 +121,7 @@ public class Constants {
      */
     public static void loadFromContext(Context context) {
         Constants.ANDROID_VERSION = android.os.Build.VERSION.RELEASE;
+        Constants.ANDROID_BUILD = android.os.Build.VERSION.BASE_OS;
         Constants.PHONE_MODEL = android.os.Build.MODEL;
         Constants.PHONE_MANUFACTURER = android.os.Build.MANUFACTURER;
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
@@ -121,7 +121,7 @@ public class Constants {
      */
     public static void loadFromContext(Context context) {
         Constants.ANDROID_VERSION = android.os.Build.VERSION.RELEASE;
-        Constants.ANDROID_BUILD = android.os.Build.VERSION.BASE_OS;
+        Constants.ANDROID_BUILD = android.os.Build.DISPLAY;
         Constants.PHONE_MODEL = android.os.Build.MODEL;
         Constants.PHONE_MANUFACTURER = android.os.Build.MANUFACTURER;
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -237,14 +237,7 @@ public class CrashManager {
         int result = STACK_TRACES_FOUND_NONE;
         if ((filenames != null) && (filenames.length > 0)) {
             try {
-                Context context = null;
-                if (weakContext != null) {
-                    context = weakContext.get();
-                    if (context != null) {
-                        SharedPreferences preferences = context.getSharedPreferences("HockeySDK", Context.MODE_PRIVATE);
-                        confirmedFilenames = Arrays.asList(preferences.getString("ConfirmedFilenames", "").split("\\|"));
-                    }
-                }
+                confirmedFilenames = getConfirmedFilenames(weakContext);
 
             } catch (Exception e) {
                 // Just in case, we catch all exceptions here
@@ -783,6 +776,18 @@ public class CrashManager {
             HockeyLog.debug(Constants.TAG, "Can't search for exception as file path is null.");
             return null;
         }
+    }
+
+    private static List<String> getConfirmedFilenames(WeakReference<Context> weakContext) {
+        List<String> result = null;
+        if (weakContext != null) {
+            Context context = weakContext.get();
+            if (context != null) {
+                SharedPreferences preferences = context.getSharedPreferences("HockeySDK", Context.MODE_PRIVATE);
+                result = Arrays.asList(preferences.getString("ConfirmedFilenames", "").split("\\|"));
+            }
+        }
+        return result;
     }
 
     public static long getInitializeTimestamp() {

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -478,7 +478,9 @@ public class CrashManager {
      */
     private static void initialize(Context context, String urlString, String appIdentifier, CrashManagerListener listener, boolean registerHandler) {
         if (context != null) {
-            CrashManager.initializeTimestamp = System.currentTimeMillis();
+            if (CrashManager.initializeTimestamp == 0) {
+                CrashManager.initializeTimestamp = System.currentTimeMillis();
+            }
             CrashManager.urlString = urlString;
             CrashManager.identifier = Util.sanitizeAppIdentifier(appIdentifier);
             CrashManager.didCrashInLastSession = false;

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -82,7 +82,7 @@ public class CrashManager {
      */
     private static boolean submitting = false;
 
-    private static boolean sDidCrashInLastSession = false;
+    private static boolean didCrashInLastSession = false;
 
     /**
      * Shared preferences key for always send dialog button.
@@ -189,7 +189,7 @@ public class CrashManager {
 
         int foundOrSend = hasStackTraces(weakContext);
         if (foundOrSend == 1) {
-            sDidCrashInLastSession = true;
+            didCrashInLastSession = true;
             Boolean autoSend = !(context instanceof Activity);
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
             autoSend |= prefs.getBoolean(ALWAYS_SEND_KEY, false);
@@ -262,7 +262,7 @@ public class CrashManager {
     }
 
     public static boolean didCrashInLastSession() {
-        return sDidCrashInLastSession;
+        return didCrashInLastSession;
     }
 
     /**
@@ -478,6 +478,7 @@ public class CrashManager {
         if (context != null) {
             CrashManager.urlString = urlString;
             CrashManager.identifier = Util.sanitizeAppIdentifier(appIdentifier);
+            CrashManager.didCrashInLastSession = false;
 
             Constants.loadFromContext(context);
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -759,7 +759,7 @@ public class CrashManager {
     }
 
     /**
-     * Searches .stacktrace files and returns then as array.
+     * Searches .stacktrace files and returns them as array.
      */
     private static String[] searchForStackTraces() {
         if (Constants.FILES_PATH != null) {

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -8,6 +8,7 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.preference.PreferenceManager;
 
+import net.hockeyapp.android.objects.CrashDetails;
 import net.hockeyapp.android.objects.CrashManagerUserInput;
 import net.hockeyapp.android.objects.CrashMetaData;
 import net.hockeyapp.android.utils.HockeyLog;
@@ -262,6 +263,40 @@ public class CrashManager {
 
     public static boolean didCrashInLastSession() {
         return didCrashInLastSession;
+    }
+
+    public static CrashDetails getLastCrashDetails() {
+        if (Constants.FILES_PATH == null || !didCrashInLastSession()) {
+            return null;
+        }
+
+        File dir = new File(Constants.FILES_PATH + "/");
+        File[] files = dir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String filename) {
+                return filename.endsWith(".stacktrace");
+            }
+        });
+
+        long lastModification = 0;
+        File lastModifiedFile = null;
+        CrashDetails result = null;
+        for (File file : files) {
+            if (file.lastModified() > lastModification) {
+                lastModification = file.lastModified();
+                lastModifiedFile = file;
+            }
+        }
+
+        if (lastModifiedFile != null && lastModifiedFile.exists()) {
+            try {
+                result = CrashDetails.fromFile(lastModifiedFile);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -82,6 +82,8 @@ public class CrashManager {
      */
     private static boolean submitting = false;
 
+    private static boolean sDidCrashInLastSession = false;
+
     /**
      * Shared preferences key for always send dialog button.
      */
@@ -187,6 +189,7 @@ public class CrashManager {
 
         int foundOrSend = hasStackTraces(weakContext);
         if (foundOrSend == 1) {
+            sDidCrashInLastSession = true;
             Boolean autoSend = !(context instanceof Activity);
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
             autoSend |= prefs.getBoolean(ALWAYS_SEND_KEY, false);
@@ -256,6 +259,10 @@ public class CrashManager {
         }
 
         return result;
+    }
+
+    public static boolean didCrashInLastSession() {
+        return sDidCrashInLastSession;
     }
 
     /**

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -82,6 +82,8 @@ public class CrashManager {
      */
     private static boolean submitting = false;
 
+    private static long initializeTimestamp;
+
     private static boolean didCrashInLastSession = false;
 
     /**
@@ -476,6 +478,7 @@ public class CrashManager {
      */
     private static void initialize(Context context, String urlString, String appIdentifier, CrashManagerListener listener, boolean registerHandler) {
         if (context != null) {
+            CrashManager.initializeTimestamp = System.currentTimeMillis();
             CrashManager.urlString = urlString;
             CrashManager.identifier = Util.sanitizeAppIdentifier(appIdentifier);
             CrashManager.didCrashInLastSession = false;
@@ -774,5 +777,9 @@ public class CrashManager {
             HockeyLog.debug(Constants.TAG, "Can't search for exception as file path is null.");
             return null;
         }
+    }
+
+    public static long getInitializeTimestamp() {
+        return initializeTimestamp;
     }
 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
@@ -116,6 +116,7 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
 
             if ((listener == null) || (listener.includeDeviceData())) {
                 writer.write("Android: " + Constants.ANDROID_VERSION + "\n");
+                writer.write("Android Build: " + Constants.ANDROID_BUILD + "\n");
                 writer.write("Manufacturer: " + Constants.PHONE_MANUFACTURER + "\n");
                 writer.write("Model: " + Constants.PHONE_MODEL + "\n");
             }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
@@ -2,6 +2,7 @@ package net.hockeyapp.android;
 
 import android.text.TextUtils;
 
+import net.hockeyapp.android.objects.CrashDetails;
 import net.hockeyapp.android.utils.HockeyLog;
 
 import java.io.BufferedWriter;
@@ -16,13 +17,13 @@ import java.util.UUID;
 
 /**
  * <h3>Description</h3>
- *
+ * <p/>
  * Helper class to catch exceptions. Saves the stack trace
  * as a file and executes callback methods to ask the app for
  * additional information and meta data (see CrashManagerListener).
- *
+ * <p/>
  * <h3>License</h3>
- *
+ * <p/>
  * <pre>
  * Copyright (c) 2009 nullwire aps
  * Copyright (c) 2011-2014 Bit Stadium GmbH
@@ -74,11 +75,11 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
 
     /**
      * Save a caught exception to disk.
-     * @deprecated in 3.7.0-beta.2. Use saveException(Throwable exception, Thread thread,
-     * CrashManagerListener listener) instead.
      *
      * @param exception Exception to save.
      * @param listener  Custom CrashManager listener instance.
+     * @deprecated in 3.7.0-beta.2. Use saveException(Throwable exception, Thread thread,
+     * CrashManagerListener listener) instead.
      */
     @Deprecated
     @SuppressWarnings("unused")
@@ -88,6 +89,7 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
 
     /**
      * Save a caught exception to disk.
+     *
      * @param exception Exception to save.
      * @param thread    Thread that crashed.
      * @param listener  Custom CrashManager listener instance.
@@ -100,57 +102,41 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
         BufferedWriter writer = null;
         exception.printStackTrace(printWriter);
 
-        try {
-            // Create filename from a random uuid
-            String filename = UUID.randomUUID().toString();
-            String path = Constants.FILES_PATH + "/" + filename + ".stacktrace";
-            HockeyLog.debug(Constants.TAG, "Writing unhandled exception to: " + path);
+        String filename = UUID.randomUUID().toString();
 
-            // Write the stacktrace to disk
-            writer = new BufferedWriter(new FileWriter(path));
+        CrashDetails crashDetails = new CrashDetails(filename, exception);
+        crashDetails.setAppPackage(Constants.APP_PACKAGE);
+        crashDetails.setAppVersionCode(Constants.APP_VERSION);
+        crashDetails.setAppVersionName(Constants.APP_VERSION_NAME);
+        crashDetails.setAppStartDate(startDate);
+        crashDetails.setAppCrashDate(now);
 
-            // HockeyApp expects the package name in the first line!
-            writer.write("Package: " + Constants.APP_PACKAGE + "\n");
-            writer.write("Version Code: " + Constants.APP_VERSION + "\n");
-            writer.write("Version Name: " + Constants.APP_VERSION_NAME + "\n");
+        if ((listener == null) || (listener.includeDeviceData())) {
+            crashDetails.setOsVersion(Constants.ANDROID_VERSION);
+            crashDetails.setOsBuild(Constants.ANDROID_BUILD);
+            crashDetails.setDeviceManufacturer(Constants.PHONE_MANUFACTURER);
+            crashDetails.setDeviceModel(Constants.PHONE_MODEL);
+        }
 
-            if ((listener == null) || (listener.includeDeviceData())) {
-                writer.write("Android: " + Constants.ANDROID_VERSION + "\n");
-                writer.write("Android Build: " + Constants.ANDROID_BUILD + "\n");
-                writer.write("Manufacturer: " + Constants.PHONE_MANUFACTURER + "\n");
-                writer.write("Model: " + Constants.PHONE_MODEL + "\n");
-            }
+        if (thread != null && ((listener == null) || (listener.includeThreadDetails()))) {
+            crashDetails.setThreadName(thread.getName() + "-" + thread.getId());
+        }
 
-            if (thread != null && ((listener == null) || (listener.includeThreadDetails()))) {
-                writer.write("Thread: " + thread.getName() + "-" + thread.getId() + "\n");
-            }
+        if (Constants.CRASH_IDENTIFIER != null && (listener == null || listener.includeDeviceIdentifier())) {
+            crashDetails.setReporterKey(Constants.CRASH_IDENTIFIER);
+        }
 
-            if (Constants.CRASH_IDENTIFIER != null && (listener == null || listener.includeDeviceIdentifier())) {
-                writer.write("CrashReporter Key: " + Constants.CRASH_IDENTIFIER + "\n");
-            }
+        crashDetails.writeCrashReport();
 
-            writer.write("Date: " + now + "\n");
-            writer.write("Start Date: " + startDate + "\n");
-            writer.write("\n");
-            writer.write(result.toString());
-            writer.flush();
-
-            if (listener != null) {
+        if (listener != null) {
+            try {
                 writeValueToFile(limitedString(listener.getUserID()), filename + ".user");
                 writeValueToFile(limitedString(listener.getContact()), filename + ".contact");
                 writeValueToFile(listener.getDescription(), filename + ".description");
-            }
-        } catch (IOException another) {
-            HockeyLog.error(Constants.TAG, "Error saving exception stacktrace!\n", another);
-        } finally {
-            try {
-                if (writer != null) {
-                    writer.close();
-                }
             } catch (IOException e) {
-                HockeyLog.error(Constants.TAG, "Error saving exception stacktrace!\n", e);
-                e.printStackTrace();
+                HockeyLog.error(Constants.TAG, "Error saving crash meta data!", e);
             }
+
         }
     }
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
@@ -94,6 +94,7 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
      */
     public static void saveException(Throwable exception, Thread thread, CrashManagerListener listener) {
         final Date now = new Date();
+        final Date startDate = new Date(CrashManager.getInitializeTimestamp());
         final Writer result = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(result);
         BufferedWriter writer = null;
@@ -128,6 +129,7 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
             }
 
             writer.write("Date: " + now + "\n");
+            writer.write("Start Date: " + startDate + "\n");
             writer.write("\n");
             writer.write(result.toString());
             writer.flush();

--- a/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
@@ -1,0 +1,287 @@
+package net.hockeyapp.android.objects;
+
+import net.hockeyapp.android.Constants;
+import net.hockeyapp.android.utils.HockeyLog;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class CrashDetails {
+
+    public static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US);
+
+    private static final String FIELD_CRASH_REPORTER_KEY = "CrashReporter Key";
+    private static final String FIELD_APP_START_DATE = "Start Date";
+    private static final String FIELD_APP_CRASH_DATE = "Date";
+    private static final String FIELD_OS_VERSION = "Android";
+    private static final String FIELD_OS_BUILD = "Android Build";
+    private static final String FIELD_DEVICE_MANUFACTURER = "Manufacturer";
+    private static final String FIELD_DEVICE_MODEL = "Model";
+    private static final String FIELD_APP_PACKAGE = "Package";
+    private static final String FIELD_APP_VERSION_NAME = "Version Name";
+    private static final String FIELD_APP_VERSION_CODE = "Version Code";
+    private static final String FIELD_THREAD_NAME = "Thread";
+
+    private final String crashIdentifier;
+
+    private String reporterKey;
+
+    private Date appStartDate;
+    private Date appCrashDate;
+
+    private String osVersion;
+    private String osBuild;
+    private String deviceManufacturer;
+    private String deviceModel;
+
+    private String appPackage;
+    private String appVersionName;
+    private String appVersionCode;
+
+    private String threadName;
+
+    private String throwableStackTrace;
+
+    public CrashDetails(String crashIdentifier) {
+        this.crashIdentifier = crashIdentifier;
+    }
+
+    public CrashDetails(String crashIdentifier, Throwable throwable) {
+        this(crashIdentifier);
+
+        final Writer stackTraceResult = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stackTraceResult);
+        throwable.printStackTrace(printWriter);
+        throwableStackTrace = stackTraceResult.toString();
+    }
+
+    public static CrashDetails fromFile(File file) throws IOException {
+        String crashIdentifier = file.getName().substring(0, file.getName().indexOf(".stacktrace"));
+        return fromReader(crashIdentifier, new FileReader(file));
+    }
+
+    public static CrashDetails fromReader(String crashIdentifier, Reader in) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(in);
+
+        CrashDetails result = new CrashDetails(crashIdentifier);
+
+        String readLine, headerName, headerValue;
+        boolean headersProcessed = false;
+        StringBuilder stackTraceBuilder = new StringBuilder();
+        while ((readLine = bufferedReader.readLine()) != null) {
+            if (!headersProcessed) {
+
+                if (readLine.isEmpty()) {
+                    // empty line denotes break between headers and stack trace
+                    headersProcessed = true;
+                    continue;
+                }
+
+                int colonIndex = readLine.indexOf(":");
+                if (colonIndex < 0) {
+                    HockeyLog.error("Malformed header line when parsing crash details: \"" + readLine + "\"");
+                }
+
+                headerName = readLine.substring(0, colonIndex).trim();
+                headerValue = readLine.substring(colonIndex + 1, readLine.length()).trim();
+
+                if (headerName.equals(FIELD_CRASH_REPORTER_KEY)) {
+                    result.setReporterKey(headerValue);
+                } else if (headerName.equals(FIELD_APP_START_DATE)) {
+                    try {
+                        result.setAppStartDate(DATE_FORMAT.parse(headerValue));
+                    } catch (ParseException e) {
+                        throw new RuntimeException(e);
+                    }
+                } else if (headerName.equals(FIELD_APP_CRASH_DATE)) {
+                    try {
+                        result.setAppCrashDate(DATE_FORMAT.parse(headerValue));
+                    } catch (ParseException e) {
+                        throw new RuntimeException(e);
+                    }
+                } else if (headerName.equals(FIELD_OS_VERSION)) {
+                    result.setOsVersion(headerValue);
+                } else if (headerName.equals(FIELD_OS_BUILD)) {
+                    result.setOsBuild(headerValue);
+                } else if (headerName.equals(FIELD_DEVICE_MANUFACTURER)) {
+                    result.setDeviceManufacturer(headerValue);
+                } else if (headerName.equals(FIELD_DEVICE_MODEL)) {
+                    result.setDeviceModel(headerValue);
+                } else if (headerName.equals(FIELD_APP_PACKAGE)) {
+                    result.setAppPackage(headerValue);
+                } else if (headerName.equals(FIELD_APP_VERSION_NAME)) {
+                    result.setAppVersionName(headerValue);
+                } else if (headerName.equals(FIELD_APP_VERSION_CODE)) {
+                    result.setAppVersionCode(headerValue);
+                } else if (headerName.equals(FIELD_THREAD_NAME)) {
+                    result.setThreadName(headerValue);
+                }
+
+            } else {
+                stackTraceBuilder.append(readLine).append("\n");
+            }
+        }
+        result.setThrowableStackTrace(stackTraceBuilder.toString());
+
+        return result;
+    }
+
+    public void writeCrashReport() {
+        String path = Constants.FILES_PATH + "/" + crashIdentifier + ".stacktrace";
+        HockeyLog.debug(Constants.TAG, "Writing unhandled exception to: " + path);
+
+        BufferedWriter writer = null;
+
+        try {
+            writer = new BufferedWriter(new FileWriter(path));
+
+            writeHeader(writer, FIELD_APP_PACKAGE, appPackage);
+            writeHeader(writer, FIELD_APP_VERSION_CODE, appVersionCode);
+            writeHeader(writer, FIELD_APP_VERSION_NAME, appVersionName);
+            writeHeader(writer, FIELD_OS_VERSION, osVersion);
+            writeHeader(writer, FIELD_OS_BUILD, osBuild);
+            writeHeader(writer, FIELD_DEVICE_MANUFACTURER, deviceManufacturer);
+            writeHeader(writer, FIELD_DEVICE_MODEL, deviceModel);
+            writeHeader(writer, FIELD_THREAD_NAME, threadName);
+            writeHeader(writer, FIELD_CRASH_REPORTER_KEY, reporterKey);
+
+            writeHeader(writer, FIELD_APP_START_DATE, DATE_FORMAT.format(appStartDate));
+            writeHeader(writer, FIELD_APP_CRASH_DATE, DATE_FORMAT.format(appCrashDate));
+
+            writer.write("\n");
+            writer.write(throwableStackTrace);
+
+            writer.flush();
+
+        } catch (IOException e) {
+            HockeyLog.error(Constants.TAG, "Error saving crash report!", e);
+        } finally {
+            try {
+                if (writer != null) {
+                    writer.close();
+                }
+            } catch (IOException e1) {
+                HockeyLog.error(Constants.TAG, "Error saving crash report!", e1);
+            }
+        }
+
+
+    }
+
+    private void writeHeader(Writer writer, String name, String value) throws IOException {
+        writer.write(name + ": " + value + "\n");
+    }
+
+    public String getCrashIdentifier() {
+        return crashIdentifier;
+    }
+
+    public String getReporterKey() {
+        return reporterKey;
+    }
+
+    public void setReporterKey(String reporterKey) {
+        this.reporterKey = reporterKey;
+    }
+
+    public Date getAppStartDate() {
+        return appStartDate;
+    }
+
+    public void setAppStartDate(Date appStartDate) {
+        this.appStartDate = appStartDate;
+    }
+
+    public Date getAppCrashDate() {
+        return appCrashDate;
+    }
+
+    public void setAppCrashDate(Date appCrashDate) {
+        this.appCrashDate = appCrashDate;
+    }
+
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    public void setOsVersion(String osVersion) {
+        this.osVersion = osVersion;
+    }
+
+    public String getOsBuild() {
+        return osBuild;
+    }
+
+    public void setOsBuild(String osBuild) {
+        this.osBuild = osBuild;
+    }
+
+    public String getDeviceManufacturer() {
+        return deviceManufacturer;
+    }
+
+    public void setDeviceManufacturer(String deviceManufacturer) {
+        this.deviceManufacturer = deviceManufacturer;
+    }
+
+    public String getDeviceModel() {
+        return deviceModel;
+    }
+
+    public void setDeviceModel(String deviceModel) {
+        this.deviceModel = deviceModel;
+    }
+
+    public String getAppPackage() {
+        return appPackage;
+    }
+
+    public void setAppPackage(String appPackage) {
+        this.appPackage = appPackage;
+    }
+
+    public String getAppVersionName() {
+        return appVersionName;
+    }
+
+    public void setAppVersionName(String appVersionName) {
+        this.appVersionName = appVersionName;
+    }
+
+    public String getAppVersionCode() {
+        return appVersionCode;
+    }
+
+    public void setAppVersionCode(String appVersionCode) {
+        this.appVersionCode = appVersionCode;
+    }
+
+    public String getThreadName() {
+        return threadName;
+    }
+
+    public void setThreadName(String threadName) {
+        this.threadName = threadName;
+    }
+
+    public String getThrowableStackTrace() {
+        return throwableStackTrace;
+    }
+
+    public void setThrowableStackTrace(String throwableStackTrace) {
+        this.throwableStackTrace = throwableStackTrace;
+    }
+
+}

--- a/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
@@ -140,7 +140,7 @@ public class CrashDetails {
 
     public void writeCrashReport() {
         String path = Constants.FILES_PATH + "/" + crashIdentifier + ".stacktrace";
-        HockeyLog.debug(Constants.TAG, "Writing unhandled exception to: " + path);
+        HockeyLog.debug("Writing unhandled exception to: " + path);
 
         BufferedWriter writer = null;
 
@@ -166,14 +166,14 @@ public class CrashDetails {
             writer.flush();
 
         } catch (IOException e) {
-            HockeyLog.error(Constants.TAG, "Error saving crash report!", e);
+            HockeyLog.error("Error saving crash report!", e);
         } finally {
             try {
                 if (writer != null) {
                     writer.close();
                 }
             } catch (IOException e1) {
-                HockeyLog.error(Constants.TAG, "Error saving crash report!", e1);
+                HockeyLog.error("Error saving crash report!", e1);
             }
         }
 


### PR DESCRIPTION
* Adds class `CrashReport` to model crash reports
* Crash reports can now be persisted to and read from disk
* Crash reports now also contain date/time of last call to `CrashManager.register(...)`
* Add means to `CrashManager` to recognize crash reports from last session and provide the last crash report
* Tests
* :cherries: on the :cake: - enables better testing scenario of crash reports in the future
