### PR TITLE
Use separate strings for different authentication methods

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/LoginActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/LoginActivity.java
@@ -10,6 +10,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import net.hockeyapp.android.tasks.LoginTask;
@@ -163,6 +164,9 @@ public class LoginActivity extends Activity {
             EditText passwordInput = (EditText) findViewById(R.id.input_password);
             passwordInput.setVisibility(View.INVISIBLE);
         }
+
+        TextView headlineText = (TextView) findViewById(R.id.text_headline);
+        headlineText.setText(mMode == LoginManager.LOGIN_MODE_EMAIL_ONLY ? R.string.hockeyapp_login_headline_text_email_only : R.string.hockeyapp_login_headline_text);
 
         mButtonLogin = (Button) findViewById(R.id.button_login);
         mButtonLogin.setOnClickListener(new View.OnClickListener() {

--- a/hockeysdk/src/main/res/values-de/strings.xml
+++ b/hockeysdk/src/main/res/values-de/strings.xml
@@ -56,6 +56,7 @@
 
     <!-- Login Activity -->
     <string name="hockeyapp_login_headline_text">Geben Sie die E-Mail-Adresse und das Kennwort Ihres HockeyApp-Accounts ein, um Zugriff auf diese App zu erhalten.</string>
+    <string name="hockeyapp_login_headline_text_email_only">Geben Sie die E-Mail-Adresse Ihres HockeyApp-Accounts ein, um Zugriff auf diese App zu erhalten.</string>
     <string name="hockeyapp_login_missing_credentials_toast">Geben Sie bitte die fehlenden Anmeldeinformationen ein.</string>
     <string name="hockeyapp_login_email_hint">E-Mail</string>
     <string name="hockeyapp_login_password_hint">Passwort</string>

--- a/hockeysdk/src/main/res/values-fr/strings.xml
+++ b/hockeysdk/src/main/res/values-fr/strings.xml
@@ -56,6 +56,7 @@
 
     <!-- Login Activity -->
     <string name="hockeyapp_login_headline_text">Saisissez l\'adresse électronique et le mot de passe de votre compte HockeyApp pour autoriser l\'accès à cette application.</string>
+    <string name="hockeyapp_login_headline_text_email_only">Saisissez l\'adresse électronique de votre compte HockeyApp pour autoriser l\'accès à cette application.</string>
     <string name="hockeyapp_login_missing_credentials_toast">Saississez l\'information de votre compte HockeyApp.</string>
     <string name="hockeyapp_login_email_hint">Email</string>
     <string name="hockeyapp_login_password_hint">Mot de passe</string>

--- a/hockeysdk/src/main/res/values/strings.xml
+++ b/hockeysdk/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
 
     <!-- Login Activity -->
     <string name="hockeyapp_login_headline_text">Please enter your HockeyApp account\'s email address and password to authorize access to this app.</string>
+    <string name="hockeyapp_login_headline_text_email_only">Please enter your HockeyApp account\'s email address to authorize access to this app.</string>
     <string name="hockeyapp_login_missing_credentials_toast">Please fill in the missing account credentials.</string>
     <string name="hockeyapp_login_email_hint">Email</string>
     <string name="hockeyapp_login_password_hint">Password</string>


### PR DESCRIPTION
Separate the UI strings for login modes email-only and email-password, update translations.