### PR TITLE
Fix potential handler leaks identified by lint

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
@@ -46,6 +46,7 @@ import net.hockeyapp.android.utils.Util;
 import net.hockeyapp.android.views.AttachmentListView;
 import net.hockeyapp.android.views.AttachmentView;
 
+import java.lang.ref.WeakReference;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -640,97 +641,14 @@ public class FeedbackActivity extends Activity implements OnClickListener {
      * Initializes the Feedback response {@link Handler}
      */
     private void initFeedbackHandler() {
-        mFeedbackHandler = new Handler() {
-            @Override
-            public void handleMessage(Message msg) {
-                boolean success = false;
-                mError = new ErrorObject();
-
-                if (msg != null && msg.getData() != null) {
-                    Bundle bundle = msg.getData();
-                    String responseString = bundle.getString(SendFeedbackTask.BUNDLE_FEEDBACK_RESPONSE);
-                    String statusCode = bundle.getString(SendFeedbackTask.BUNDLE_FEEDBACK_STATUS);
-                    String requestType = bundle.getString(SendFeedbackTask.BUNDLE_REQUEST_TYPE);
-                    if ((requestType.equals("send") && ((responseString == null) || (Integer.parseInt(statusCode) != 201)))) {
-                        // Send feedback went wrong if response is empty or status code != 201
-                        mError.setMessage(getString(R.string.hockeyapp_feedback_send_generic_error));
-                    } else if ((requestType.equals("fetch") && (statusCode != null) && ((Integer.parseInt(statusCode) == 404) || (Integer.parseInt(statusCode) == 422)))) {
-                        // Fetch feedback went wrong if status code is 404 or 422
-                        resetFeedbackView();
-                        success = true;
-                    } else if (responseString != null) {
-                        startParseFeedbackTask(responseString, requestType);
-                        success = true;
-                    } else {
-                        mError.setMessage(getString(R.string.hockeyapp_feedback_send_network_error));
-                    }
-                } else {
-                    mError.setMessage(getString(R.string.hockeyapp_feedback_send_generic_error));
-                }
-
-                if (!success) {
-                    runOnUiThread(new Runnable() {
-
-                        @SuppressWarnings("deprecation")
-                        @Override
-                        public void run() {
-                            enableDisableSendFeedbackButton(true);
-                            showDialog(DIALOG_ERROR_ID);
-                        }
-                    });
-                }
-
-                onSendFeedbackResult(success);
-            }
-        };
+        mFeedbackHandler = new FeedbackHandler(this);
     }
 
     /**
      * Initialize the Feedback response parse result {@link Handler}
      */
     private void initParseFeedbackHandler() {
-        mParseFeedbackHandler = new Handler() {
-            @Override
-            public void handleMessage(Message msg) {
-                boolean success = false;
-                mError = new ErrorObject();
-
-                if (msg != null && msg.getData() != null) {
-                    Bundle bundle = msg.getData();
-                    FeedbackResponse feedbackResponse = (FeedbackResponse) bundle.getSerializable(ParseFeedbackTask.BUNDLE_PARSE_FEEDBACK_RESPONSE);
-                    if (feedbackResponse != null) {
-                        if (feedbackResponse.getStatus().equalsIgnoreCase("success")) {
-                            /** We have a valid result from JSON parsing */
-                            success = true;
-
-                            if (feedbackResponse.getToken() != null) {
-                                /** Save the Token to SharedPreferences */
-                                PrefsUtil.getInstance().saveFeedbackTokenToPrefs(mContext, feedbackResponse.getToken());
-                                /** Load the existing feedback messages */
-                                loadFeedbackMessages(feedbackResponse);
-                                mInSendFeedback = false;
-                            }
-                        } else {
-                            success = false;
-                        }
-                    }
-                }
-
-                /** Something went wrong, so display an error dialog */
-                if (!success) {
-                    runOnUiThread(new Runnable() {
-
-                        @SuppressWarnings("deprecation")
-                        @Override
-                        public void run() {
-                            showDialog(DIALOG_ERROR_ID);
-                        }
-                    });
-                }
-
-                enableDisableSendFeedbackButton(true);
-            }
-        };
+        mParseFeedbackHandler = new ParseFeedbackHandler(this);
     }
 
     /**
@@ -874,5 +792,120 @@ public class FeedbackActivity extends Activity implements OnClickListener {
     private void startParseFeedbackTask(String feedbackResponseString, String requestType) {
         createParseFeedbackTask(feedbackResponseString, requestType);
         AsyncTaskUtils.execute(mParseFeedbackTask);
+    }
+
+    private static class FeedbackHandler extends Handler {
+
+        private final WeakReference<FeedbackActivity> mWeakFeedbackActivity;
+
+        public FeedbackHandler(FeedbackActivity feedbackActivity) {
+            mWeakFeedbackActivity = new WeakReference<>(feedbackActivity);
+        }
+
+        @Override
+        public void handleMessage(Message msg) {
+            boolean success = false;
+            ErrorObject error = new ErrorObject();
+
+            final FeedbackActivity feedbackActivity = mWeakFeedbackActivity.get();
+            if (feedbackActivity == null) {
+                return;
+            }
+
+            if (msg != null && msg.getData() != null) {
+                Bundle bundle = msg.getData();
+                String responseString = bundle.getString(SendFeedbackTask.BUNDLE_FEEDBACK_RESPONSE);
+                String statusCode = bundle.getString(SendFeedbackTask.BUNDLE_FEEDBACK_STATUS);
+                String requestType = bundle.getString(SendFeedbackTask.BUNDLE_REQUEST_TYPE);
+                if ((requestType.equals("send") && ((responseString == null) || (Integer.parseInt(statusCode) != 201)))) {
+                    // Send feedback went wrong if response is empty or status code != 201
+                    error.setMessage(feedbackActivity.getString(R.string.hockeyapp_feedback_send_generic_error));
+                } else if ((requestType.equals("fetch") && (statusCode != null) && ((Integer.parseInt(statusCode) == 404) || (Integer.parseInt(statusCode) == 422)))) {
+                    // Fetch feedback went wrong if status code is 404 or 422
+                    feedbackActivity.resetFeedbackView();
+                    success = true;
+                } else if (responseString != null) {
+                    feedbackActivity.startParseFeedbackTask(responseString, requestType);
+                    success = true;
+                } else {
+                    error.setMessage(feedbackActivity.getString(R.string.hockeyapp_feedback_send_network_error));
+                }
+            } else {
+                error.setMessage(feedbackActivity.getString(R.string.hockeyapp_feedback_send_generic_error));
+            }
+
+            feedbackActivity.mError = error;
+
+            if (!success) {
+                feedbackActivity.runOnUiThread(new Runnable() {
+
+                    @SuppressWarnings("deprecation")
+                    @Override
+                    public void run() {
+                        feedbackActivity.enableDisableSendFeedbackButton(true);
+                        feedbackActivity.showDialog(DIALOG_ERROR_ID);
+                    }
+                });
+            }
+
+            feedbackActivity.onSendFeedbackResult(success);
+        }
+
+    }
+
+    private static class ParseFeedbackHandler extends Handler {
+
+        private final WeakReference<FeedbackActivity> mWeakFeedbackActivity;
+
+        public ParseFeedbackHandler(FeedbackActivity feedbackActivity) {
+            mWeakFeedbackActivity = new WeakReference<>(feedbackActivity);
+        }
+
+        @Override
+        public void handleMessage(Message msg) {
+            boolean success = false;
+
+            final FeedbackActivity feedbackActivity = mWeakFeedbackActivity.get();
+            if (feedbackActivity == null) {
+                return;
+            }
+
+            feedbackActivity.mError = new ErrorObject();
+
+            if (msg != null && msg.getData() != null) {
+                Bundle bundle = msg.getData();
+                FeedbackResponse feedbackResponse = (FeedbackResponse) bundle.getSerializable(ParseFeedbackTask.BUNDLE_PARSE_FEEDBACK_RESPONSE);
+                if (feedbackResponse != null) {
+                    if (feedbackResponse.getStatus().equalsIgnoreCase("success")) {
+                        /** We have a valid result from JSON parsing */
+                        success = true;
+
+                        if (feedbackResponse.getToken() != null) {
+                            /** Save the Token to SharedPreferences */
+                            PrefsUtil.getInstance().saveFeedbackTokenToPrefs(feedbackActivity, feedbackResponse.getToken());
+                            /** Load the existing feedback messages */
+                            feedbackActivity.loadFeedbackMessages(feedbackResponse);
+                            feedbackActivity.mInSendFeedback = false;
+                        }
+                    } else {
+                        success = false;
+                    }
+                }
+            }
+
+            /** Something went wrong, so display an error dialog */
+            if (!success) {
+                feedbackActivity.runOnUiThread(new Runnable() {
+
+                    @SuppressWarnings("deprecation")
+                    @Override
+                    public void run() {
+                        feedbackActivity.showDialog(DIALOG_ERROR_ID);
+                    }
+                });
+            }
+
+            feedbackActivity.enableDisableSendFeedbackButton(true);
+        }
     }
 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/LoginActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/LoginActivity.java
@@ -178,24 +178,7 @@ public class LoginActivity extends Activity {
     }
 
     private void initLoginHandler() {
-        mLoginHandler = new Handler() {
-            @Override
-            public void handleMessage(Message msg) {
-                Bundle bundle = msg.getData();
-                boolean success = bundle.getBoolean(LoginTask.BUNDLE_SUCCESS);
-
-                if (success) {
-                    finish();
-
-                    if (LoginManager.listener != null) {
-                        LoginManager.listener.onSuccess();
-                    }
-                } else {
-                    Toast.makeText(LoginActivity.this, "Login failed. Check your credentials.", Toast.LENGTH_LONG)
-                            .show();
-                }
-            }
-        };
+        mLoginHandler = new LoginHandler(this);
     }
 
     private void performAuthentication() {
@@ -250,5 +233,31 @@ public class LoginActivity extends Activity {
             e.printStackTrace();
         }
         return "";
+    }
+
+    private static class LoginHandler extends Handler {
+
+        private final Activity mActivity;
+
+        public LoginHandler(Activity activity) {
+            mActivity = activity;
+        }
+
+        @Override
+        public void handleMessage(Message msg) {
+            Bundle bundle = msg.getData();
+            boolean success = bundle.getBoolean(LoginTask.BUNDLE_SUCCESS);
+
+            if (success) {
+                mActivity.finish();
+
+                if (LoginManager.listener != null) {
+                    LoginManager.listener.onSuccess();
+                }
+            } else {
+                Toast.makeText(mActivity, "Login failed. Check your credentials.", Toast.LENGTH_LONG)
+                        .show();
+            }
+        }
     }
 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/LoginActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/LoginActivity.java
@@ -17,6 +17,7 @@ import net.hockeyapp.android.tasks.LoginTask;
 import net.hockeyapp.android.utils.AsyncTaskUtils;
 import net.hockeyapp.android.utils.Util;
 
+import java.lang.ref.WeakReference;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -237,25 +238,31 @@ public class LoginActivity extends Activity {
 
     private static class LoginHandler extends Handler {
 
-        private final Activity mActivity;
+        private final WeakReference<Activity> mWeakActivity;
 
         public LoginHandler(Activity activity) {
-            mActivity = activity;
+            mWeakActivity = new WeakReference<>(activity);
         }
 
         @Override
         public void handleMessage(Message msg) {
+
+            final Activity activity = mWeakActivity.get();
+            if (activity == null) {
+                return;
+            }
+
             Bundle bundle = msg.getData();
             boolean success = bundle.getBoolean(LoginTask.BUNDLE_SUCCESS);
 
             if (success) {
-                mActivity.finish();
+                activity.finish();
 
                 if (LoginManager.listener != null) {
                     LoginManager.listener.onSuccess();
                 }
             } else {
-                Toast.makeText(mActivity, "Login failed. Check your credentials.", Toast.LENGTH_LONG)
+                Toast.makeText(activity, "Login failed. Check your credentials.", Toast.LENGTH_LONG)
                         .show();
             }
         }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/LoginManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/LoginManager.java
@@ -159,17 +159,7 @@ public class LoginManager {
             LoginManager.mainActivity = activity;
 
             if (LoginManager.validateHandler == null) {
-                LoginManager.validateHandler = new Handler() {
-                    @Override
-                    public void handleMessage(Message msg) {
-                        Bundle bundle = msg.getData();
-                        boolean success = bundle.getBoolean(LoginTask.BUNDLE_SUCCESS);
-
-                        if (!success) {
-                            startLoginActivity(context);
-                        }
-                    }
-                };
+                LoginManager.validateHandler = new LoginHandler(context);
             }
 
             Constants.loadFromContext(context);
@@ -254,5 +244,24 @@ public class LoginManager {
         }
 
         return urlString + "api/3/apps/" + identifier + "/identity/" + suffix;
+    }
+
+    private static class LoginHandler extends Handler {
+
+        private final Context mContext;
+
+        public LoginHandler(Context context) {
+            mContext = context;
+        }
+
+        @Override
+        public void handleMessage(Message msg) {
+            Bundle bundle = msg.getData();
+            boolean success = bundle.getBoolean(LoginTask.BUNDLE_SUCCESS);
+
+            if (!success) {
+                startLoginActivity(mContext);
+            }
+        }
     }
 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/LoginManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/LoginManager.java
@@ -13,6 +13,7 @@ import net.hockeyapp.android.tasks.LoginTask;
 import net.hockeyapp.android.utils.AsyncTaskUtils;
 import net.hockeyapp.android.utils.Util;
 
+import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -248,10 +249,10 @@ public class LoginManager {
 
     private static class LoginHandler extends Handler {
 
-        private final Context mContext;
+        private final WeakReference<Context> mWeakContext;
 
         public LoginHandler(Context context) {
-            mContext = context;
+            mWeakContext = new WeakReference<>(context);
         }
 
         @Override
@@ -259,8 +260,13 @@ public class LoginManager {
             Bundle bundle = msg.getData();
             boolean success = bundle.getBoolean(LoginTask.BUNDLE_SUCCESS);
 
+            Context context = mWeakContext.get();
+            if (context == null) {
+                return;
+            }
+
             if (!success) {
-                startLoginActivity(mContext);
+                startLoginActivity(context);
             }
         }
     }


### PR DESCRIPTION
Move some anonymous handler classes to static inner classes - thus preventing leaking of activity/context instances. 
Needs thorough testing, if potential leaks have been fixed, and everything works as before.