### PR TITLE
Fix npe on listfiles in isFreeSpaceAvailable() method

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/metrics/Persistence.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/metrics/Persistence.java
@@ -269,12 +269,13 @@ class Persistence {
         // TODO Check for available disk space as well.
         synchronized (LOCK) {
             Context context = getContext();
-            if ((context.getFilesDir()) != null) {
+            if (context.getFilesDir() != null) {
                 File filesDir = context.getFilesDir();
                 String path = filesDir.getAbsolutePath() + BIT_TELEMETRY_DIRECTORY;
                 if (!TextUtils.isEmpty(path)) {
                     File dir = new File(path);
-                    return (dir.listFiles().length < MAX_FILE_COUNT);
+                    File[] files = dir.listFiles();
+                    return files != null && files.length < MAX_FILE_COUNT;
                 }
             }
             return false;


### PR DESCRIPTION
@ranterle Fixes #182 and #184 

- `listFiles()` can return null. See here:
> If this abstract pathname does not denote a directory, then this method returns null. Otherwise an array of File objects is returned, one for each file or directory in the directory. 
Source: https://developer.android.com/reference/java/io/File.html#listFiles().