### PR TITLE
Add forceNewThread flag which allows Feedback to always create a new message thread

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
@@ -598,7 +598,7 @@ public class FeedbackActivity extends Activity implements OnClickListener {
 
     private void configureAppropriateView() {
         /** Try to retrieve the Feedback Token from {@link SharedPreferences} */
-        if(!mForceNewThread || mInSendFeedback) {
+        if (!mForceNewThread || mInSendFeedback) {
             mToken = PrefsUtil.getInstance().getFeedbackTokenFromPrefs(this);
         }
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
@@ -68,6 +68,11 @@ public class FeedbackActivity extends Activity implements OnClickListener {
     public static final String EXTRA_URL = "url";
 
     /**
+     * Optional extra that can be passed as {@code true} to force a new feedback message thread.
+     */
+    public static final String EXTRA_FORCE_NEW_THREAD = "forceNewThread";
+
+    /**
      * Extra for initial username to set for the feedback message.
      */
     public static final String EXTRA_INITIAL_USER_NAME = "initialUserName";
@@ -166,6 +171,12 @@ public class FeedbackActivity extends Activity implements OnClickListener {
     private boolean mInSendFeedback;
 
     /**
+     * Indicates if a new thread should be created for each new feedback message as opposed to
+     * the default resume thread behaviour.
+     */
+    private boolean mForceNewThread;
+
+    /**
      * True when the view was initialized
      **/
     private boolean mFeedbackViewInitialized;
@@ -193,6 +204,7 @@ public class FeedbackActivity extends Activity implements OnClickListener {
         Bundle extras = getIntent().getExtras();
         if (extras != null) {
             mUrl = extras.getString(EXTRA_URL);
+            mForceNewThread = extras.getBoolean(EXTRA_FORCE_NEW_THREAD);
             initialUserName = extras.getString(EXTRA_INITIAL_USER_NAME);
             initialUserEmail = extras.getString(EXTRA_INITIAL_USER_EMAIL);
 
@@ -316,8 +328,8 @@ public class FeedbackActivity extends Activity implements OnClickListener {
                 openContextMenu(v);
             }
         } else if (viewId == R.id.button_add_response) {
-            configureFeedbackView(false);
             mInSendFeedback = true;
+            configureFeedbackView(false);
         } else if (viewId == R.id.button_refresh) {
             sendFetchFeedback(mUrl, null, null, null, null, null, PrefsUtil.getInstance().getFeedbackTokenFromPrefs(mContext), mFeedbackHandler, true);
         }
@@ -494,7 +506,7 @@ public class FeedbackActivity extends Activity implements OnClickListener {
                         mNameInput.setText(nameEmailSubjectArray[0]);
                         mEmailInput.setText(nameEmailSubjectArray[1]);
 
-                        if (nameEmailSubjectArray.length >= 3) {
+                        if (!mForceNewThread && nameEmailSubjectArray.length >= 3) {
                             mSubjectInput.setText(nameEmailSubjectArray[2]);
                             mTextInput.requestFocus();
                         } else {
@@ -524,8 +536,8 @@ public class FeedbackActivity extends Activity implements OnClickListener {
             /** Reset the remaining fields if previously populated */
             mTextInput.setText("");
 
-            /** Check to see if the Feedback Token is availabe */
-            if (PrefsUtil.getInstance().getFeedbackTokenFromPrefs(mContext) != null) {
+            /** Check to see if the Feedback Token is available */
+            if ((!mForceNewThread || mInSendFeedback) && PrefsUtil.getInstance().getFeedbackTokenFromPrefs(mContext) != null) {
                 /** If Feedback Token is available, hide the Subject Input field */
                 mSubjectInput.setVisibility(View.GONE);
             } else {
@@ -586,8 +598,11 @@ public class FeedbackActivity extends Activity implements OnClickListener {
 
     private void configureAppropriateView() {
         /** Try to retrieve the Feedback Token from {@link SharedPreferences} */
-        mToken = PrefsUtil.getInstance().getFeedbackTokenFromPrefs(this);
-        if ((mToken == null) || (mInSendFeedback)) {
+        if(!mForceNewThread || mInSendFeedback) {
+            mToken = PrefsUtil.getInstance().getFeedbackTokenFromPrefs(this);
+        }
+
+        if (mToken == null || mInSendFeedback) {
             /** If Feedback Token is NULL, show the usual feedback view */
             configureFeedbackView(false);
         } else {
@@ -708,7 +723,7 @@ public class FeedbackActivity extends Activity implements OnClickListener {
         enableDisableSendFeedbackButton(false);
         hideKeyboard();
 
-        String token = PrefsUtil.getInstance().getFeedbackTokenFromPrefs(mContext);
+        String token = mForceNewThread && !mInSendFeedback ? null : PrefsUtil.getInstance().getFeedbackTokenFromPrefs(mContext);
 
         String name = mNameInput.getText().toString().trim();
         String email = mEmailInput.getText().toString().trim();

--- a/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackManager.java
@@ -79,6 +79,12 @@ public class FeedbackManager {
     private static String urlString = null;
 
     /**
+     * Indicates if a new thread should be created for each new feedback message as opposed to
+     * the default resume thread behaviour.
+     */
+    private static boolean forceNewThread;
+
+    /**
      * Whether the user's name is required.
      */
     private static FeedbackUserDataElement requireUserName = FeedbackUserDataElement.REQUIRED;
@@ -191,6 +197,7 @@ public class FeedbackManager {
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             intent.setClass(context, activityClass);
             intent.putExtra(FeedbackActivity.EXTRA_URL, getURLString(context));
+            intent.putExtra(FeedbackActivity.EXTRA_FORCE_NEW_THREAD, forceNewThread);
             intent.putExtra(FeedbackActivity.EXTRA_INITIAL_USER_NAME, userName);
             intent.putExtra(FeedbackActivity.EXTRA_INITIAL_USER_EMAIL, userEmail);
             intent.putExtra(FeedbackActivity.EXTRA_INITIAL_ATTACHMENTS, attachments);
@@ -248,6 +255,19 @@ public class FeedbackManager {
      */
     private static String getURLString(Context context) {
         return urlString + "api/2/apps/" + identifier + "/feedback/";
+    }
+
+    /**
+     * Indicates if a new thread should be created for each new feedback message
+     +
+     + Setting this to {@code true} will force a new thread whenever a new message is sent as
+     + opposed to the default resume thread behaviour.
+     *
+     * @param forceNewThread {@code true} if you want to force new threads for each message,
+     *                       otherwise {@code false} (default).
+     */
+    public static void setForceNewThread(final boolean forceNewThread) {
+        FeedbackManager.forceNewThread = forceNewThread;
     }
 
     /**

--- a/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackManager.java
@@ -79,12 +79,6 @@ public class FeedbackManager {
     private static String urlString = null;
 
     /**
-     * Indicates if a new thread should be created for each new feedback message as opposed to
-     * the default resume thread behaviour.
-     */
-    private static boolean forceNewThread;
-
-    /**
      * Whether the user's name is required.
      */
     private static FeedbackUserDataElement requireUserName = FeedbackUserDataElement.REQUIRED;
@@ -189,6 +183,7 @@ public class FeedbackManager {
             if (activityClass == null) {
                 activityClass = FeedbackActivity.class;
             }
+            boolean forceNewThread = lastListener != null && lastListener.shouldCreateNewFeedbackThread();
 
             Intent intent = new Intent();
             if (extras != null && !extras.isEmpty()) {
@@ -255,19 +250,6 @@ public class FeedbackManager {
      */
     private static String getURLString(Context context) {
         return urlString + "api/2/apps/" + identifier + "/feedback/";
-    }
-
-    /**
-     * Indicates if a new thread should be created for each new feedback message
-     +
-     + Setting this to {@code true} will force a new thread whenever a new message is sent as
-     + opposed to the default resume thread behaviour.
-     *
-     * @param forceNewThread {@code true} if you want to force new threads for each message,
-     *                       otherwise {@code false} (default).
-     */
-    public static void setForceNewThread(final boolean forceNewThread) {
-        FeedbackManager.forceNewThread = forceNewThread;
     }
 
     /**

--- a/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackManagerListener.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackManagerListener.java
@@ -26,4 +26,12 @@ public abstract class FeedbackManagerListener {
      * and false if not and a notification should be fired.
      */
     public abstract boolean feedbackAnswered(FeedbackMessage latestMessage);
+
+    /**
+     * Called when posting a new feedback message.
+     * @return Whether a new feedback thread should be created or not. Defaults to false.
+     */
+    public boolean shouldCreateNewFeedbackThread() {
+        return false;
+    }
 }


### PR DESCRIPTION
This PR adds a new configuration option which allows a new feedback thread to be created each time the feedback form is submitted instead of the default which adds a new message to the existing feedback thread.

This is useful in scenarios where feedback is used more for bug reporting and feature requests then as a user communication tool.

This is the same change/feature as the iOS SDK repo PR https://github.com/bitstadium/HockeySDK-iOS/pull/359

Example ussage: 
```java
FeedbackManager.register(context, "<KEY>");
FeedbackManager.setForceNewThread(true); // <---
FeedbackManager.setUserEmail(userEmail);
FeedbackManager.setUserName(userName);
...
```

The "ADD A RESPONSE" button continues to add a message to the existing thread, via the `mInSendFeedback` attribute.