### PR TITLE
Set up max SDK Version for WRITE_EXTERNAL_STORAGE

### DIFF
--- a/hockeysdk/src/main/AndroidManifest.xml
+++ b/hockeysdk/src/main/AndroidManifest.xml
@@ -5,7 +5,10 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="22"
+    />
 
     <application>
 


### PR DESCRIPTION
Set max SDK for WRITE_EXTERNAL_STORAGE to SDK 22 as it is used by an optional feature. Read at: https://support.hockeyapp.net/discussions/problems/63807-android-6-external-storage-permissions-crash-reporting

This way, the default behaviour would be to not include it in the merged manifest with Runtime Permissions. However, the developer can still include the permission manually if the project requires in-app updates. Moreover, in this case (Android 6+), the developer needs to ask for the permission anyway.

I think that it is a good practice to be aware of merged dangerous permissions and add them manually instead of removing them manually.