### PR TITLE
Limit post fields to 4 MiB in size

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/HttpURLConnectionBuilder.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/HttpURLConnectionBuilder.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * <h3>Description</h3>
@@ -32,6 +33,7 @@ public class HttpURLConnectionBuilder {
 
     private static final int DEFAULT_TIMEOUT = 2 * 60 * 1000;
     public static final String DEFAULT_CHARSET = "UTF-8";
+    public static final long FORM_FIELD_LIMIT = 4 * 1024 * 1024;
 
     private final String mUrlString;
 
@@ -59,6 +61,14 @@ public class HttpURLConnectionBuilder {
     }
 
     public HttpURLConnectionBuilder writeFormFields(Map<String, String> fields) {
+
+        for (String key: fields.keySet()) {
+            String value = fields.get(key);
+            if (value.length() > FORM_FIELD_LIMIT) {
+                throw new IllegalArgumentException("Form field " + key + " size too large: " + value.length() + " - max allowed: " + FORM_FIELD_LIMIT);
+            }
+        }
+
         try {
             String formString = getFormString(fields, DEFAULT_CHARSET);
             setHeader("Content-Type", "application/x-www-form-urlencoded");

--- a/hockeysdk/src/test/java/net/hockeyapp/android/utils/HttpURLConnectionBuilderTest.java
+++ b/hockeysdk/src/test/java/net/hockeyapp/android/utils/HttpURLConnectionBuilderTest.java
@@ -1,0 +1,26 @@
+package net.hockeyapp.android.utils;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpURLConnectionBuilderTest {
+
+    private static final String TEST_URL = "https://sdk.hockeyapp.net";
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFormFieldSizeLimit() {
+
+        String mockString = new String(new char[(4 * 1024 * 1024) + 1]).replace('\0', ' ');
+
+        HttpURLConnectionBuilder builder = new HttpURLConnectionBuilder(TEST_URL);
+        builder.setRequestMethod("POST");
+
+        Map<String, String> fields = new HashMap<>();
+        fields.put("test", mockString);
+
+        builder.writeFormFields(fields);
+    }
+
+}


### PR DESCRIPTION
There has been an issue with uploading stack traces from the SDK to HockeyApp. The issue only occurs for very large stack traces (several MB, ~ 100MB in the particular case), and then causes an OOM [here](https://github.com/bitstadium/HockeySDK-Android/blob/0d958c86ab65c9ea7b48ae4036854cb0f4b629ca/hockeysdk/src/main/java/net/hockeyapp/android/utils/HttpURLConnectionBuilder.java#L178). By it's very nature, an OOM can not be handled gracefully, so we can only try to prevent it.
As it is difficult to gauge the exact memory left or reclaimable by the VM - and difficult to gauge the memory needs of `URLEncoder.encode()` before execution, we need to define a limit of our own.
I think 4 MiB for any form field are plenty, the biggest in our SDK being the raw stack trace.

We could also think of limiting the stack trace we send, so it never exceeds this size.