### PR TITLE
Initialize more fields in CrashDetails constructor

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
@@ -56,8 +56,6 @@ public class CrashDetails {
 
     public CrashDetails(String crashIdentifier) {
         this.crashIdentifier = crashIdentifier;
-        appStartDate = new Date();
-        appCrashDate = new Date();
         isXamarinException = false;
         throwableStackTrace = "";
     }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
@@ -56,6 +56,10 @@ public class CrashDetails {
 
     public CrashDetails(String crashIdentifier) {
         this.crashIdentifier = crashIdentifier;
+        appStartDate = new Date();
+        appCrashDate = new Date();
+        isXamarinException = false;
+        throwableStackTrace = "";
     }
 
     public CrashDetails(String crashIdentifier, Throwable throwable) {


### PR DESCRIPTION
In order to avoid an Exception when calling writeCrashReport, initialize
the following members to default values:
* appStartDate
* appCrashDate
* isXamarinException
* throwableStackTrace

Fixes #200