### PR TITLE
CrashDetails.writeCrashReport(final String path)

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
@@ -184,6 +184,10 @@ public class CrashDetails {
 
     public void writeCrashReport() {
         String path = Constants.FILES_PATH + "/" + crashIdentifier + ".stacktrace";
+        writeCrashReport(path);
+    }
+
+    public void writeCrashReport(final String path) {
         HockeyLog.debug("Writing unhandled exception to: " + path);
 
         BufferedWriter writer = null;


### PR DESCRIPTION
Allows users of CrashDetails to specify the desired path for the crash
report to be written.

Fixes #202