### PR TITLE
Fix LoginActivity behaviour

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/LoginActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/LoginActivity.java
@@ -121,10 +121,12 @@ public class LoginActivity extends Activity {
             if (LoginManager.listener != null) {
                 LoginManager.listener.onBack();
             } else {
-                Intent intent = new Intent(this, LoginManager.mainActivity);
-                intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                intent.putExtra(LoginManager.LOGIN_EXIT_KEY, true);
-                startActivity(intent);
+                if (LoginManager.mainActivity != null) {
+                    Intent intent = new Intent(this, LoginManager.mainActivity);
+                    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                    intent.putExtra(LoginManager.LOGIN_EXIT_KEY, true);
+                    startActivity(intent);
+                }
                 return true;
             }
         }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/LoginManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/LoginManager.java
@@ -241,7 +241,7 @@ public class LoginManager {
         //So we override the mode variable with LOGIN_MODE_EMAIL_PASSWORD
         Boolean isLoginModeValidate = (mode == LOGIN_MODE_VALIDATE) ? true : false;
         int tempMode = (isLoginModeValidate) ? LOGIN_MODE_EMAIL_PASSWORD : mode;
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_NO_HISTORY);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.setClass(context, LoginActivity.class);
         intent.putExtra(LoginActivity.EXTRA_URL, getURLString(tempMode));
         intent.putExtra(LoginActivity.EXTRA_MODE, tempMode);


### PR DESCRIPTION
This PR does the following 

1. Fixes issue #204

Per [documentation](https://support.hockeyapp.net/kb/client-integration-android/authenticating-users-on-android), if I want to protect all my app, I need put `LoginManager` initialization code in `onCreate` method in my main activity. But after hide\restore my app login dialog disappears, and user will have full access to the application.

To prevent issue above I propose to remove `Intent.FLAG_ACTIVITY_NO_HISTORY` - because this activity is opened in new task, and manually closed by call `finish()` method, this flag may be safety removed. 


2. Adds `Intent.FLAG_ACTIVITY_CLEAR_TOP` flag to prevent duplicate login dialog in case of `
LoginManager.verifyLogin` was called twice.

3. Fixes app crash when back button is pressed and no activity is passed by user: extra test for `LoginManager.mainActivity` is not null.