### PR TITLE
1 line change to trigger onCrashesNotSent when there is no internet connection

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -575,6 +575,7 @@ public class CrashManager {
         Context ctx = weakContext.get();
         if (ctx != null && !Util.isConnectedToNetwork(ctx)) {
             // Not connected to network, not trying to submit stack traces
+            listener.onCrashesNotSent();
             return;
         }
 


### PR DESCRIPTION
After reporting this issue : https://github.com/bitstadium/HockeySDK-Android/issues/220

I found that if there is no internet connection, listener.onCrashesNotSent is not trigger. In my case I need to always know after crash detected to if crash is sent or not to be able to continue the execution of my application.

Thank you