### PR TITLE
Fixes bug with resource leak

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/metrics/Sender.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/metrics/Sender.java
@@ -124,6 +124,8 @@ public class Sender {
 
             if ((persistedData != null) && (connection != null)) {
                 send(connection, fileToSend, persistedData);
+            }
+            if (connection != null){
                 connection.disconnect();
             }
         }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/metrics/Sender.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/metrics/Sender.java
@@ -125,7 +125,7 @@ public class Sender {
             if ((persistedData != null) && (connection != null)) {
                 send(connection, fileToSend, persistedData);
             }
-            if (connection != null){
+            if (connection != null) {
                 connection.disconnect();
             }
         }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/metrics/Sender.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/metrics/Sender.java
@@ -124,6 +124,7 @@ public class Sender {
 
             if ((persistedData != null) && (connection != null)) {
                 send(connection, fileToSend, persistedData);
+                connection.disconnect();
             }
         }
     }


### PR DESCRIPTION
Fixes bug with resource leak crash in a strict mode. A bug can be reproduced with the following code
```
try {
   for(int i = 0; i < 100; i++){
     Log.d("CYCLE", "i = " + i );
     MetricsManager.trackEvent("Closeable leak");
     Thread.sleep(750 + (long)(Math.random() * 1250));
   }
 } catch (InterruptedException e) {
      e.printStackTrace();
 }
```
It seems like the problem is not calling disconnect method after the connection is used.