### PR TITLE
Fix FeedbackActivity NPE

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/FeedbackActivity.java
@@ -129,7 +129,7 @@ public class FeedbackActivity extends Activity implements OnClickListener, View.
     /**
      * Initial attachment uris
      */
-    private List<Uri> mInitialAttachments;
+    private List<Uri> mInitialAttachments = new ArrayList<>();
 
     /**
      * Reference to this
@@ -216,7 +216,7 @@ public class FeedbackActivity extends Activity implements OnClickListener, View.
 
             Parcelable[] initialAttachmentsArray = extras.getParcelableArray(EXTRA_INITIAL_ATTACHMENTS);
             if (initialAttachmentsArray != null) {
-                mInitialAttachments = new ArrayList<>();
+                mInitialAttachments.clear();
                 for (Parcelable parcelable : initialAttachmentsArray) {
                     mInitialAttachments.add((Uri) parcelable);
                 }
@@ -262,7 +262,7 @@ public class FeedbackActivity extends Activity implements OnClickListener, View.
             ArrayList<Uri> attachmentsUris = savedInstanceState.getParcelableArrayList("attachments");
             if (attachmentsUris != null) {
                 for (Uri attachmentUri : attachmentsUris) {
-                    if (mInitialAttachments == null || !mInitialAttachments.contains(attachmentUri)) {
+                    if (!mInitialAttachments.contains(attachmentUri)) {
                         mAttachmentListView.addView(new AttachmentView(this, mAttachmentListView, attachmentUri, true));
                     }
                 }
@@ -535,10 +535,8 @@ public class FeedbackActivity extends Activity implements OnClickListener, View.
             /** Reset the attachment list */
             mAttachmentListView.removeAllViews();
 
-            if (mInitialAttachments != null) {
-                for (Uri attachmentUri : mInitialAttachments) {
-                    mAttachmentListView.addView(new AttachmentView(this, mAttachmentListView, attachmentUri, true));
-                }
+            for (Uri attachmentUri : mInitialAttachments) {
+                mAttachmentListView.addView(new AttachmentView(this, mAttachmentListView, attachmentUri, true));
             }
 
             /** Use of context menu needs to be enabled explicitly */


### PR DESCRIPTION
## Issue:
`mInitialAttachments` in `FeedbackActivity` is not initialized. Instead of checking, let's make sure it is always non-null.

## Error:
```
java.lang.NullPointerException: Attempt to invoke interface method 'boolean java.util.List.removeAll(java.util.Collection)' on a null object reference
at net.hockeyapp.android.FeedbackActivity$FeedbackHandler.handleMessage(FeedbackActivity.java:849)
at android.os.Handler.dispatchMessage(Handler.java:105)
at android.os.Looper.loop(Looper.java:164)
at android.app.ActivityThread.main(ActivityThread.java:6541)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```