### PR TITLE
Decrement latch count down in background to thread

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -203,14 +203,14 @@ public class CrashManager {
                     SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
                     autoSend |= prefs.getBoolean(ALWAYS_SEND_KEY, false);
                 }
-                return hasStackTraces(weakContext);
+                int foundOrSend = hasStackTraces(weakContext);
+                didCrashInLastSession = foundOrSend == STACK_TRACES_FOUND_NEW;
+                latch.countDown();
+                return foundOrSend;
             }
 
             @Override
             protected void onPostExecute(Integer foundOrSend) {
-                didCrashInLastSession = foundOrSend == STACK_TRACES_FOUND_NEW;
-                latch.countDown();
-
                 boolean autoSend = this.autoSend;
                 boolean ignoreDefaultHandler = (listener != null) && (listener.ignoreDefaultHandler());
 


### PR DESCRIPTION
There is a deadlock situation when user tries to get info if app crashed in the last session after registering CrashManager like this:

```
CrashManager.register(this);
boolean didCrash = CrashManager.didCrashInLastSession().get();
```

get() call blocks main thread and onPostExecute method of the AsyncTask in 

```
public static void execute(Context context, final CrashManagerListener listener)
```

can not run, since main thread is blocked, and latch countdown does not get decremented.