### PR TITLE
Check if MetricsManager instance is actually initialized in sessionTr…

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/metrics/MetricsManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/metrics/MetricsManager.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.Log;
 
 import net.hockeyapp.android.Constants;
 import net.hockeyapp.android.PrivateEventManager;
@@ -283,7 +282,13 @@ public class MetricsManager {
      * @return YES if session tracking is enabled
      */
     public static boolean sessionTrackingEnabled() {
-        return isUserMetricsEnabled() && !instance.mSessionTrackingDisabled;
+        if (instance == null) {
+            HockeyLog.error(TAG, "MetricsManager hasn't been registered or User Metrics has been disabled. No User Metrics will be collected!");
+            return false;
+        }
+        else {
+            return isUserMetricsEnabled() && !instance.mSessionTrackingDisabled;
+        }
     }
 
     /**
@@ -468,7 +473,7 @@ public class MetricsManager {
             return;
         }
         if (instance == null) {
-            Log.w(TAG, "MetricsManager hasn't been registered or User Metrics has been disabled. No User Metrics will be collected!");
+            HockeyLog.error(TAG, "MetricsManager hasn't been registered or User Metrics has been disabled. No User Metrics will be collected!");
             return;
         }
         if (!isUserMetricsEnabled()) {


### PR DESCRIPTION
…ackingEnabled

Fixes a potential crash when calling `sessionTrackingEnabled()` before calling `MetricsManager.register()`.