### PR TITLE
Use count of stack traces from the last search on save exception

### DIFF
--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerHelper.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerHelper.java
@@ -16,8 +16,6 @@ public class CrashManagerHelper {
     }
 
     public static void reset(Context context) {
-
-        // Needed to get directory to write fake crashes
         CrashManager.weakContext = new WeakReference<>(context);
         CrashManager.latch = new CountDownLatch(1);
         CrashManager.stackTracesCount = 0;

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerHelper.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerHelper.java
@@ -20,6 +20,7 @@ public class CrashManagerHelper {
         // Needed to get directory to write fake crashes
         CrashManager.weakContext = new WeakReference<>(context);
         CrashManager.latch = new CountDownLatch(1);
+        CrashManager.stackTracesCount = 0;
     }
 
     public static File cleanFiles(Context context) {

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerTest.java
@@ -61,6 +61,7 @@ public class CrashManagerTest {
 
         // verify that there were no crashes in the last session
         assertFalse(CrashManager.didCrashInLastSession().get());
+        assertEquals(0, CrashManager.stackTracesCount);
     }
 
     @Test
@@ -71,6 +72,7 @@ public class CrashManagerTest {
 
         assertTrue(CrashManager.didCrashInLastSession().get());
         assertNotNull(CrashManager.getLastCrashDetails(InstrumentationRegistry.getTargetContext()).get());
+        assertEquals(1, CrashManager.stackTracesCount);
     }
 
     @Test
@@ -80,8 +82,8 @@ public class CrashManagerTest {
         CrashManager.register(InstrumentationRegistry.getTargetContext(), DUMMY_APP_IDENTIFIER);
 
         CrashDetails crashDetails = CrashManager.getLastCrashDetails(InstrumentationRegistry.getTargetContext()).get();
-
         assertNotNull(crashDetails);
+        assertEquals(1, CrashManager.stackTracesCount);
 
         File lastStackTrace = lastCrashReportFile();
         assertNotNull(lastStackTrace);
@@ -94,8 +96,8 @@ public class CrashManagerTest {
         fakeCrashReport();
 
         crashDetails = CrashManager.getLastCrashDetails(InstrumentationRegistry.getTargetContext()).get();
-
         assertNotNull(crashDetails);
+        assertEquals(4, CrashManager.stackTracesCount);
 
         lastStackTrace = lastCrashReportFile();
         assertNotNull(lastStackTrace);
@@ -113,6 +115,7 @@ public class CrashManagerTest {
 
         CrashDetails crashDetails = CrashManager.getLastCrashDetails(InstrumentationRegistry.getTargetContext()).get();
         assertNotNull(crashDetails);
+        assertEquals(2, CrashManager.stackTracesCount);
         assertEquals(crashDetails.getFormat(), "Xamarin");
         String throwableStackTrace = crashDetails.getThrowableStackTrace();
         Boolean containsCausedByXamarin = throwableStackTrace.contains("Xamarin caused by:");

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/ExceptionHandlerTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/ExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package net.hockeyapp.android;
 
+import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -10,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.lang.ref.WeakReference;
 
 import static org.junit.Assert.*;
 
@@ -25,7 +27,6 @@ public class ExceptionHandlerTest {
         filesDirectory = CrashManagerHelper.cleanFiles(InstrumentationRegistry.getTargetContext());
     }
 
-    @SuppressWarnings("ThrowableInstanceNeverThrown")
     @Test
     public void saveExceptionTest() {
 
@@ -39,6 +40,40 @@ public class ExceptionHandlerTest {
 
         files = filesDirectory.listFiles(new StacktraceFilenameFilter());
         assertEquals(3, files.length);
+    }
+
+    @Test
+    public void maxFilesTest() {
+        WeakReference<Context> weakContext = new WeakReference<>(InstrumentationRegistry.getTargetContext());
+        String[] files;
+        for (int i = 0; i < CrashManager.MAX_NUMBER_OF_CRASHFILES; i++) {
+            files = CrashManager.searchForStackTraces(weakContext);
+            assertNotNull(files);
+            assertEquals(i, files.length);
+            assertEquals(i, CrashManager.stackTracesCount);
+
+            fakeCrashReport();
+        }
+
+        files = CrashManager.searchForStackTraces(weakContext);
+        assertNotNull(files);
+        assertEquals(CrashManager.MAX_NUMBER_OF_CRASHFILES, files.length);
+        assertEquals(CrashManager.MAX_NUMBER_OF_CRASHFILES, CrashManager.stackTracesCount);
+
+        fakeCrashReport();
+
+        files = CrashManager.searchForStackTraces(weakContext);
+        assertNotNull(files);
+        assertEquals(CrashManager.MAX_NUMBER_OF_CRASHFILES, files.length);
+        assertEquals(CrashManager.MAX_NUMBER_OF_CRASHFILES, CrashManager.stackTracesCount);
+
+        fakeCrashReport();
+        fakeCrashReport();
+
+        files = CrashManager.searchForStackTraces(weakContext);
+        assertNotNull(files);
+        assertEquals(CrashManager.MAX_NUMBER_OF_CRASHFILES, files.length);
+        assertEquals(CrashManager.MAX_NUMBER_OF_CRASHFILES, CrashManager.stackTracesCount);
     }
 
     @SuppressWarnings("ThrowableInstanceNeverThrown")

--- a/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
@@ -61,14 +61,10 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
         }
 
         // Check for number of crashes on disk and don't save the crash in case we reached the defined limit.
-        final String[] list = CrashManager.searchForStackTraces(CrashManager.weakContext);
-        if (list != null) {
-            HockeyLog.debug("ExceptionHandler: Found " + list.length + " stacktrace(s).");
-            if (list.length >= CrashManager.MAX_NUMBER_OF_CRASHFILES) {
-                HockeyLog.warn("ExceptionHandler: HockeyApp will not save this exception as there are already " +
-                        CrashManager.MAX_NUMBER_OF_CRASHFILES + " or more unsent exceptions on disk");
-                return;
-            }
+        if (CrashManager.stackTracesCount >= CrashManager.MAX_NUMBER_OF_CRASHFILES) {
+            HockeyLog.warn("ExceptionHandler: HockeyApp will not save this exception as there are already " +
+                    CrashManager.MAX_NUMBER_OF_CRASHFILES + " or more unsent exceptions on disk");
+            return;
         }
 
         String filename = UUID.randomUUID().toString();


### PR DESCRIPTION
Avoid additional disk IO on saving exception.
Should help with #331 