### PR TITLE
Remove `android:supportsRtl` attribute from AndroidManifest

### DIFF
--- a/hockeysdk/build.gradle
+++ b/hockeysdk/build.gradle
@@ -18,7 +18,7 @@ android {
         }
     }
     lintOptions {
-        disable 'GoogleAppIndexingWarning'
+        disable 'GoogleAppIndexingWarning','RtlEnabled'
         textReport true
     }
 }

--- a/hockeysdk/src/main/AndroidManifest.xml
+++ b/hockeysdk/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
-    <application android:supportsRtl="true">
+    <application>
 
         <activity android:name=".UpdateActivity" />
         <activity android:name=".FeedbackActivity" android:windowSoftInputMode="adjustResize|stateVisible" />


### PR DESCRIPTION
The resources in the SDK might support RTL layouts, but the consuming app might not. In fact, when they explicitly set `supportsRtl` to `false` on their application, this causes a conflict when creating the merged manifest, causing the build to fail. 

So it is probably best not to set the attribute and ignore the lint warning.

Fixes #334.