### PR TITLE
Fix possible deadlock

### DIFF
--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/ConstantsTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/ConstantsTest.java
@@ -19,7 +19,7 @@ public class ConstantsTest {
     @Test
     public void testLoadingConstantsWorks() throws Exception {
         Constants.loadFromContext(InstrumentationRegistry.getContext());
-        Constants.LOADING_LATCH.await();
+        Constants.DEVICE_IDENTIFIER.get();
 
         assertNotNull(Constants.BASE_URL);
         assertEquals("https://sdk.hockeyapp.net/", Constants.BASE_URL);

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerHelper.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/CrashManagerHelper.java
@@ -10,9 +10,9 @@ import java.util.concurrent.CountDownLatch;
 
 public class CrashManagerHelper {
 
-    public static void loadConstants(Context context) throws InterruptedException {
+    public static void loadConstants(Context context) throws Exception {
         Constants.loadFromContext(context);
-        Constants.LOADING_LATCH.await();
+        Constants.DEVICE_IDENTIFIER.get();
     }
 
     public static void reset(Context context) {

--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/TrackingTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/TrackingTest.java
@@ -31,7 +31,7 @@ public class TrackingTest {
              * will write to a different preferences key than the test tracking module
              */
             Constants.loadFromContext(mActivityRule.getActivity());
-            Constants.LOADING_LATCH.await();
+            Constants.DEVICE_IDENTIFIER.get();
         }
     }
 

--- a/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/CrashManager.java
@@ -15,6 +15,7 @@ import net.hockeyapp.android.objects.CrashDetails;
 import net.hockeyapp.android.objects.CrashManagerUserInput;
 import net.hockeyapp.android.objects.CrashMetaData;
 import net.hockeyapp.android.utils.AsyncTaskUtils;
+import net.hockeyapp.android.utils.CompletedFuture;
 import net.hockeyapp.android.utils.HockeyLog;
 import net.hockeyapp.android.utils.HttpURLConnectionBuilder;
 import net.hockeyapp.android.utils.Util;
@@ -302,6 +303,9 @@ public class CrashManager {
 
     @SuppressWarnings("WeakerAccess")
     public static Future<Boolean> didCrashInLastSession() {
+        if (latch.getCount() == 0) {
+            return new CompletedFuture<>(didCrashInLastSession);
+        }
         return AsyncTaskUtils.execute(new Callable<Boolean>() {
 
             @Override

--- a/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
@@ -16,6 +16,7 @@ import java.io.Writer;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Date;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 
 /**
  * <h3>Description</h3>
@@ -88,9 +89,11 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
         }
 
         // Get device identifier without waiting for initialization to avoid deadlock.
-        String deviceIdentifier = Constants.DEVICE_IDENTIFIER;
-        if (deviceIdentifier != null && (listener == null || listener.includeDeviceIdentifier())) {
-            crashDetails.setReporterKey(deviceIdentifier);
+        if (Constants.DEVICE_IDENTIFIER.isDone() && (listener == null || listener.includeDeviceIdentifier())) {
+            try {
+                crashDetails.setReporterKey(Constants.DEVICE_IDENTIFIER.get());
+            } catch (InterruptedException | ExecutionException ignored) {
+            }
         }
 
         crashDetails.writeCrashReport(context);
@@ -180,9 +183,11 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
         }
 
         // Get device identifier without waiting for initialization to avoid deadlock.
-        String deviceIdentifier = Constants.DEVICE_IDENTIFIER;
-        if (deviceIdentifier != null && (listener == null || listener.includeDeviceIdentifier())) {
-            crashDetails.setReporterKey(deviceIdentifier);
+        if (Constants.DEVICE_IDENTIFIER.isDone() && (listener == null || listener.includeDeviceIdentifier())) {
+            try {
+                crashDetails.setReporterKey(Constants.DEVICE_IDENTIFIER.get());
+            } catch (InterruptedException | ExecutionException ignored) {
+            }
         }
 
         crashDetails.writeCrashReport(context);

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/CompletedFuture.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/CompletedFuture.java
@@ -13,7 +13,7 @@ public class CompletedFuture<T> implements Future<T> {
     }
 
     @Override
-    public boolean cancel(final boolean b) {
+    public boolean cancel(final boolean mayInterruptIfRunning) {
         return false;
     }
 
@@ -34,7 +34,7 @@ public class CompletedFuture<T> implements Future<T> {
 
     @SuppressWarnings("NullableProblems")
     @Override
-    public T get(final long l, final TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+    public T get(final long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         return mResult;
     }
 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/LatchFuture.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/LatchFuture.java
@@ -1,0 +1,48 @@
+package net.hockeyapp.android.utils;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class LatchFuture<T> implements Future<T> {
+    private T mResult;
+    private CountDownLatch mLatch = new CountDownLatch(1);
+
+    public synchronized void complete(T result) throws IllegalStateException {
+        if (isDone()) {
+            throw new IllegalStateException();
+        }
+        mResult = result;
+        mLatch.countDown();
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return mLatch.getCount() == 0;
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        mLatch.await();
+        return mResult;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        mLatch.await(timeout, unit);
+        return mResult;
+    }
+}


### PR DESCRIPTION
Here are following improvements:
- `Constants.getDeviceIdentifier()` don't wait main thread;
- `Constants.getDeviceIdentifier()` don't use thread pool;
- Add check to prevent generate device id multiple times;
- Return didCrashInLastSession immediately, if we do not need to wait;