### PR TITLE
Truncate large stacktraces

### DIFF
--- a/hockeysdk/src/androidTest/java/net/hockeyapp/android/objects/CrashDetailsTest.java
+++ b/hockeysdk/src/androidTest/java/net/hockeyapp/android/objects/CrashDetailsTest.java
@@ -19,7 +19,6 @@ import org.mockito.stubbing.Answer;
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.Arrays;
-import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -93,7 +92,7 @@ public class CrashDetailsTest {
         }).when(throwableSpy).printStackTrace(any(PrintWriter.class));
 
         CrashDetails details = new CrashDetails("id", throwableSpy);
-        assertTrue("Crash stacktrace was not truncated", details.getThrowableStackTrace().length() <= CrashDetails.CRASH_FILE_STACKTRACE_MAX_SIZE);
+        assertTrue("Crash stacktrace was not truncated", details.getThrowableStackTrace().length() <= CrashDetails.CRASH_FILE_STACKTRACE_SIZE);
     }
 
     @Test
@@ -126,6 +125,6 @@ public class CrashDetailsTest {
         CrashDetails details = new CrashDetails("id", throwableSpy, managedException, false);
         final int xamarinHeaderLength = CrashDetails.FIELD_XAMARIN_CAUSED_BY.length();
         assertTrue("Crash stacktrace was not truncated",
-                details.getThrowableStackTrace().length() <= CrashDetails.CRASH_FILE_STACKTRACE_MAX_SIZE + xamarinHeaderLength);
+                details.getThrowableStackTrace().length() <= CrashDetails.CRASH_FILE_STACKTRACE_SIZE + xamarinHeaderLength);
     }
 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/ExceptionHandler.java
@@ -50,9 +50,6 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
     public static void saveException(Throwable exception, Thread thread, CrashManagerListener listener) {
         final Date now = new Date();
         final Date startDate = new Date(CrashManager.getInitializeTimestamp());
-        final Writer result = new StringWriter();
-        final PrintWriter printWriter = new PrintWriter(result);
-        exception.printStackTrace(printWriter);
 
         Context context = CrashManager.weakContext != null ? CrashManager.weakContext.get() : null;
         if (context == null)
@@ -150,12 +147,6 @@ public class ExceptionHandler implements UncaughtExceptionHandler {
         final Date startDate = new Date(CrashManager.getInitializeTimestamp());
         String filename = UUID.randomUUID().toString();
         final Date now = new Date();
-
-        final Writer result = new StringWriter();
-        final PrintWriter printWriter = new PrintWriter(result);
-        if (exception != null) {
-            exception.printStackTrace(printWriter);
-        }
 
         Context context = CrashManager.weakContext != null ? CrashManager.weakContext.get() : null;
         if (context == null)

--- a/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/objects/CrashDetails.java
@@ -22,6 +22,8 @@ import java.util.Date;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class CrashDetails {
+    protected static final int STACKTRACE_MAX_LENGTH = 4 * 1024 * 1024;
+
     private static final String FIELD_CRASH_REPORTER_KEY = "CrashReporter Key";
     private static final String FIELD_APP_START_DATE = "Start Date";
     private static final String FIELD_APP_CRASH_DATE = "Date";
@@ -219,8 +221,10 @@ public class CrashDetails {
             }
 
             writer.write("\n");
+            if (throwableStackTrace.length() > STACKTRACE_MAX_LENGTH) {
+                throwableStackTrace = throwableStackTrace.substring(0, throwableStackTrace.lastIndexOf('\n', STACKTRACE_MAX_LENGTH - 1) + 1);
+            }
             writer.write(throwableStackTrace);
-
             writer.flush();
 
         } catch (IOException e) {

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/BoundedPrintWriter.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/BoundedPrintWriter.java
@@ -1,40 +1,50 @@
 package net.hockeyapp.android.utils;
 
-import java.io.PrintWriter;
+import java.io.IOException;
 import java.io.Writer;
 
-public class BoundedPrintWriter extends PrintWriter {
+public class BoundedPrintWriter extends Writer {
 
     private final int maxLength;
-    private final String lineSeparator;
-
+    private final Writer out;
     private int currentLength = 0;
 
     public BoundedPrintWriter(Writer out, int maxLength) {
         super(out);
+        this.out = out;
         this.maxLength = maxLength;
-        this.lineSeparator = System.getProperty("line.separator");
     }
 
     @Override
     public void write(char[] buf, int off, int len) {
-        if (currentLength + len < maxLength) {
-            super.write(buf, off, len);
-            currentLength += len;
-        } else {
-            super.write(buf, off, maxLength - currentLength);
-            currentLength = maxLength;
+        try {
+            if (currentLength + len < maxLength) {
+                out.write(buf, off, len);
+                currentLength += len;
+            } else {
+                out.write(buf, off, maxLength - currentLength);
+                currentLength = maxLength;
+            }
         }
+        catch (IOException ignored) { }
     }
 
     @Override
-    public void write(String s, int off, int len) {
-        char [] buffer = s.toCharArray();
-        write(buffer, 0, buffer.length);
+    public void close() {
+        try {
+            if (out == null) {
+                return;
+            }
+            out.close();
+        }
+        catch (IOException ignored) {}
     }
 
     @Override
-    public void println() {
-        write(lineSeparator);
+    public void flush() {
+        try {
+            out.flush();
+        }
+        catch (IOException ignored) {}
     }
 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/BoundedPrintWriter.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/BoundedPrintWriter.java
@@ -6,12 +6,14 @@ import java.io.Writer;
 public class BoundedPrintWriter extends PrintWriter {
 
     private final int maxLength;
+    private final String lineSeparator;
 
     private int currentLength = 0;
 
     public BoundedPrintWriter(Writer out, int maxLength) {
         super(out);
         this.maxLength = maxLength;
+        this.lineSeparator = System.getProperty("line.separator");
     }
 
     @Override
@@ -23,5 +25,16 @@ public class BoundedPrintWriter extends PrintWriter {
             super.write(buf, off, maxLength - currentLength);
             currentLength = maxLength;
         }
+    }
+
+    @Override
+    public void write(String s, int off, int len) {
+        char [] buffer = s.toCharArray();
+        write(buffer, 0, buffer.length);
+    }
+
+    @Override
+    public void println() {
+        write(lineSeparator);
     }
 }

--- a/hockeysdk/src/main/java/net/hockeyapp/android/utils/BoundedPrintWriter.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/utils/BoundedPrintWriter.java
@@ -1,0 +1,27 @@
+package net.hockeyapp.android.utils;
+
+import java.io.PrintWriter;
+import java.io.Writer;
+
+public class BoundedPrintWriter extends PrintWriter {
+
+    private final int maxLength;
+
+    private int currentLength = 0;
+
+    public BoundedPrintWriter(Writer out, int maxLength) {
+        super(out);
+        this.maxLength = maxLength;
+    }
+
+    @Override
+    public void write(char[] buf, int off, int len) {
+        if (currentLength + len < maxLength) {
+            super.write(buf, off, len);
+            currentLength += len;
+        } else {
+            super.write(buf, off, maxLength - currentLength);
+            currentLength = maxLength;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds truncating stack traces during save process. We already are truncating big crash reports during sending, but to avoid issues like #377, we need to truncate them before saving.