### PR TITLE
Removed android:maxSdkVersion="18" from Manifest

### DIFF
--- a/hockeysdk/src/main/AndroidManifest.xml
+++ b/hockeysdk/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application>


### PR DESCRIPTION
Removed android:maxSdkVersion="18" from Manifest, to solve WRITE_EXTERNAL STORAGE permission problems in Apps using this permission.

https://github.com/bitstadium/HockeySDK-Android/issues/356