### PR TITLE
Test tls enforcement for android sdk less than Lollipop.

### DIFF
--- a/hockeysdk/build.gradle
+++ b/hockeysdk/build.gradle
@@ -17,6 +17,11 @@ android {
             minifyEnabled false
         }
     }
+    testOptions {
+        unitTests.all {
+            jvmArgs '-noverify'
+        }
+    }
     lintOptions {
         disable 'GoogleAppIndexingWarning','RtlEnabled'
         textReport true

--- a/hockeysdk/src/test/java/net/hockeyapp/android/TestUtils.java
+++ b/hockeysdk/src/test/java/net/hockeyapp/android/TestUtils.java
@@ -1,0 +1,32 @@
+package net.hockeyapp.android;
+
+import org.junit.After;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public final class TestUtils {
+
+    /**
+     * Use this method as a last resort alternative when Whitebox.setInternalState fails
+     * on static final variable and you are using the PowerMockRule (or just mockito).
+     * Please note that even this method will be useless if the constant is inlined by the compiler
+     * (e.g. the constant is directly a String or number or boolean, for that method to work,
+     * the static final variable must be the result of a method call).
+     * You need to reset the state on a {@link After} method to avoid side effects on other tests.
+     *
+     * @param clazz     class containing the field.
+     * @param fieldName field name.
+     * @param value     value to set.
+     * @throws Exception if an exception occurs.
+     */
+    @SuppressWarnings({"SameParameterValue", "JavaReflectionMemberAccess"})
+    public static void setInternalState(Class clazz, String fieldName, Object value) throws Exception {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Field modifiers = field.getClass().getDeclaredField("modifiers");
+        modifiers.setAccessible(true);
+        modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, value);
+    }
+}

--- a/hockeysdk/src/test/java/net/hockeyapp/android/utils/HttpsURLConnectionBuilderTest.java
+++ b/hockeysdk/src/test/java/net/hockeyapp/android/utils/HttpsURLConnectionBuilderTest.java
@@ -1,13 +1,66 @@
 package net.hockeyapp.android.utils;
 
-import org.junit.Test;
+import android.os.Build;
+import android.text.TextUtils;
 
+import net.hockeyapp.android.TestUtils;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@SuppressWarnings("unused")
+@PrepareForTest({
+        HttpsURLConnectionBuilder.class,
+        TextUtils.class
+})
 public class HttpsURLConnectionBuilderTest {
 
     private static final String TEST_URL = "https://sdk.hockeyapp.net";
+
+    @Rule
+    public PowerMockRule mRule = new PowerMockRule();
+
+    @Before
+    public void setup() {
+        mockStatic(TextUtils.class);
+        Mockito.when(TextUtils.isEmpty(any(CharSequence.class))).thenAnswer(new Answer<Boolean>() {
+
+            @Override
+            public Boolean answer(InvocationOnMock invocation) {
+                CharSequence str = (CharSequence) invocation.getArguments()[0];
+                return str == null || str.length() == 0;
+            }
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", 0);
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void testFormFieldSizeLimit() {
@@ -37,4 +90,30 @@ public class HttpsURLConnectionBuilderTest {
         builder.writeFormFields(fields);
     }
 
+    @Test
+    public void tls1_2Enforcement() throws Exception {
+        for (int apiLevel = Build.VERSION_CODES.JELLY_BEAN; apiLevel <= Build.VERSION_CODES.LOLLIPOP; apiLevel++) {
+            testTls1_2Setting(apiLevel, 1);
+        }
+        for (int apiLevel = Build.VERSION_CODES.LOLLIPOP_MR1; apiLevel <= Build.VERSION_CODES.O_MR1; apiLevel++) {
+            testTls1_2Setting(apiLevel, 0);
+        }
+    }
+
+    private void testTls1_2Setting(int apiLevel, int tlsSetExpectedCalls) throws Exception {
+        TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", apiLevel);
+        URL url = mock(URL.class);
+        whenNew(URL.class).withArguments(TEST_URL).thenReturn(url);
+        HttpsURLConnection urlConnection = mock(HttpsURLConnection.class);
+        Mockito.when(url.openConnection()).thenReturn(urlConnection);
+        HttpsURLConnectionBuilder builder = new HttpsURLConnectionBuilder(TEST_URL);
+        builder.build();
+        verify(urlConnection, times(tlsSetExpectedCalls)).setSSLSocketFactory(argThat(new ArgumentMatcher<SSLSocketFactory>() {
+
+            @Override
+            public boolean matches(Object argument) {
+                return argument instanceof TLS1_2SocketFactory;
+            }
+        }));
+    }
 }


### PR DESCRIPTION
Additional tests for TLS support as mentioned in the comment below:
https://github.com/bitstadium/HockeySDK-Android/pull/422#issuecomment-492930517